### PR TITLE
Fix axios call signatures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,8 @@ export default class Kitsu {
       const url = this.plural(this.resCase(res)) + (id ? '/' + id : '')
       const { data } = await axios.get(url, {
         params,
-        paramsSerializer: p => query(p),
+        paramsSerializer: p => query(p)
+      }, {
         headers: Object.assign(this.headers, headers, jsonAPIHeader)
       })
 
@@ -178,8 +179,9 @@ export default class Kitsu {
 
       const url = this.plural(this.resCase(model)) + '/' + body.id
       const { data } = await axios.patch(url, {
-        data: (await serialise.apply(this, [ model, body, 'PATCH' ])).data,
-        headers
+        data: (await serialise.apply(this, [ model, body, 'PATCH' ])).data
+      }, {
+        headers: Object.assign(this.headers, headers, jsonAPIHeader)
       })
 
       return data
@@ -219,8 +221,9 @@ export default class Kitsu {
 
       const url = this.plural(this.resCase(model))
       const { data } = await axios.post(url, {
-        data: (await serialise.apply(this, [ model, body ])).data,
-        headers
+        data: (await serialise.apply(this, [ model, body ])).data
+      }, {
+        headers: Object.assign(this.headers, headers, jsonAPIHeader)
       })
 
       return data
@@ -249,8 +252,9 @@ export default class Kitsu {
 
       const url = this.plural(this.resCase(model)) + '/' + id
       const { data } = await axios.delete(url, {
-        data: (await serialise.apply(this, [ model, { id }, 'DELETE' ])).data,
-        headers
+        data: (await serialise.apply(this, [ model, { id }, 'DELETE' ])).data
+      }, {
+        headers: Object.assign(this.headers, headers, jsonAPIHeader)
       })
 
       return data

--- a/src/index.js
+++ b/src/index.js
@@ -144,9 +144,7 @@ export default class Kitsu {
       const { data } = await axios.get(url, {
         params,
         paramsSerializer: p => query(p)
-      }, {
-        headers: Object.assign(this.headers, headers, jsonAPIHeader)
-      })
+      }, { headers: Object.assign(this.headers, headers, jsonAPIHeader) })
 
       return deserialise(data)
     } catch (E) {
@@ -180,9 +178,7 @@ export default class Kitsu {
       const url = this.plural(this.resCase(model)) + '/' + body.id
       const { data } = await axios.patch(url, {
         data: (await serialise.apply(this, [ model, body, 'PATCH' ])).data
-      }, {
-        headers: Object.assign(this.headers, headers, jsonAPIHeader)
-      })
+      }, { headers })
 
       return data
     } catch (E) {
@@ -222,9 +218,7 @@ export default class Kitsu {
       const url = this.plural(this.resCase(model))
       const { data } = await axios.post(url, {
         data: (await serialise.apply(this, [ model, body ])).data
-      }, {
-        headers: Object.assign(this.headers, headers, jsonAPIHeader)
-      })
+      }, { headers })
 
       return data
     } catch (E) {
@@ -253,9 +247,7 @@ export default class Kitsu {
       const url = this.plural(this.resCase(model)) + '/' + id
       const { data } = await axios.delete(url, {
         data: (await serialise.apply(this, [ model, { id }, 'DELETE' ])).data
-      }, {
-        headers: Object.assign(this.headers, headers, jsonAPIHeader)
-      })
+      }, { headers })
 
       return data
     } catch (E) {


### PR DESCRIPTION
The axios api apparently changed and we weren't looking.

Headers are now passed to axios in separate "config" parameter dict
instead of in the "data" dict.

Fixes #86