### PR TITLE
Improve kitsu typings to prevent CommonJS style require imports

### DIFF
--- a/packages/kitsu/index.d.ts
+++ b/packages/kitsu/index.d.ts
@@ -1,4 +1,4 @@
-export = Kitsu;
+export default Kitsu;
 
 declare class Kitsu {
     constructor(...args: any[]);


### PR DESCRIPTION
Currently the `Kitsu` class is exported using
```ts
export = Kitsu;
```
which means, when using it, we've to import it using CommonJS `require`:
```ts
import Kitsu = require("kitsu");
```

But if we export it using
```ts
export default Kitsu;
```
we can import it like this:
```ts
import Kitsu from "kitsu"
```