### PR TITLE
fix(kitsu-core): changed & to &&

### DIFF
--- a/packages/kitsu-core/src/serialise/index.js
+++ b/packages/kitsu-core/src/serialise/index.js
@@ -105,7 +105,7 @@ export async function serialise (model, obj = {}, method = 'POST') {
     for (let key in obj) {
       const node = obj[key]
       const nodeType = this.plural(this.camel(key))
-      if (node !== null & node.constructor === Object) {
+      if (node !== null && node.constructor === Object) {
         data = await serialiseObject(node, nodeType, key, data, method)
       } else if (node !== null && Array.isArray(node)) {
         data = await serialiseArray(node, nodeType, key, data, method)


### PR DESCRIPTION
I fixed an operator that should be logical and but was written as bitwise and. This causes issues when `node` is `null`. If the code was written properly, the `node !== null` expression would short-circuit the `&&` operator and `node.constructor` would not be evaluated. However, with `&` both expressions are evaluated, raising an error when trying to reference the `constructor` property on `null`.