### PR TITLE
Alias interceptors from axios to Kitsu

### DIFF
--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -26,30 +26,6 @@ import { camel, deserialise, error, kebab, query, serialise, snake } from 'kitsu
  *     Authorization: 'Bearer 1234567890'
  *   }
  * })
- * @example <caption>Using Interceptors</caption>
- * // Add a request interceptor
- * api.interceptors.request.use(function (config) {
- *    // Do something before request is sent
- *    return config;
- * }, function (error) {
- *    // Do something with request error
- *    return Promise.reject(error);
- * });
- *
- * // Add a response interceptor
- * api.interceptors.response.use(function (response) {
- *    // Any status code that lie within the range of 2xx cause this function to trigger
- *    // Do something with response data
- *    return response;
- * }, function (error) {
- *    // Any status codes that falls outside the range of 2xx cause this function to trigger
- *    // Do something with response error
- *    return Promise.reject(error);
- * });
- *
- * // Remove an interceptor
- * const myInterceptor = api.interceptors.request.use(function () {...});
- * api.interceptors.request.eject(myInterceptor);
  */
 export default class Kitsu {
   constructor (options = {}) {
@@ -101,6 +77,37 @@ export default class Kitsu {
     this.update = this.patch
     this.create = this.post
     this.remove = this.delete
+    
+    /**
+     * Axios Interceptors (alias of `axios.interceptors`)
+     *
+     * You can intercept responses before they are handled by `get`, `post`, `patch` and `delete` and before requests are sent to the API server.
+     *
+     * @memberof Kitsu
+     * @example <caption>Request Interceptor</caption>
+     * // Add a request interceptor
+     * api.interceptors.request.use(config => {
+     *    // Do something before request is sent
+     *    return config;
+     * }, error => {
+     *    // Do something with request error
+     *    return Promise.reject(error);
+     * });
+     * @example <caption>Response Interceptor</caption>
+     * // Add a response interceptor
+     * api.interceptors.response.use(response => {
+     *    // Any status code that lie within the range of 2xx cause this function to trigger
+     *    // Do something with response data
+     *    return response;
+     * }, error => {
+     *    // Any status codes that falls outside the range of 2xx cause this function to trigger
+     *    // Do something with response error
+     *    return Promise.reject(error);
+     * });
+     * @example <caption>Removing Interceptors</caption>
+     * const myInterceptor = api.interceptors.request.use(function () {...});
+     * api.interceptors.request.eject(myInterceptor);
+     */
     this.interceptors = this.axios.interceptors
   }
 

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -26,6 +26,30 @@ import { camel, deserialise, error, kebab, query, serialise, snake } from 'kitsu
  *     Authorization: 'Bearer 1234567890'
  *   }
  * })
+ * @example <caption>Using Interceptors</caption>
+ * // Add a request interceptor
+ * api.interceptors.request.use(function (config) {
+ *    // Do something before request is sent
+ *    return config;
+ * }, function (error) {
+ *    // Do something with request error
+ *    return Promise.reject(error);
+ * });
+ *
+ * // Add a response interceptor
+ * api.interceptors.response.use(function (response) {
+ *    // Any status code that lie within the range of 2xx cause this function to trigger
+ *    // Do something with response data
+ *    return response;
+ * }, function (error) {
+ *    // Any status codes that falls outside the range of 2xx cause this function to trigger
+ *    // Do something with response error
+ *    return Promise.reject(error);
+ * });
+ *
+ * // Remove an interceptor
+ * const myInterceptor = api.interceptors.request.use(function () {...});
+ * api.interceptors.request.eject(myInterceptor);
  */
 export default class Kitsu {
   constructor (options = {}) {

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -77,7 +77,7 @@ export default class Kitsu {
     this.update = this.patch
     this.create = this.post
     this.remove = this.delete
-    
+
     /**
      * Axios Interceptors (alias of `axios.interceptors`)
      *
@@ -88,25 +88,25 @@ export default class Kitsu {
      * // Add a request interceptor
      * api.interceptors.request.use(config => {
      *    // Do something before request is sent
-     *    return config;
+     *    return config
      * }, error => {
      *    // Do something with request error
-     *    return Promise.reject(error);
-     * });
+     *    return Promise.reject(error)
+     * })
      * @example <caption>Response Interceptor</caption>
      * // Add a response interceptor
      * api.interceptors.response.use(response => {
      *    // Any status code that lie within the range of 2xx cause this function to trigger
      *    // Do something with response data
-     *    return response;
+     *    return response
      * }, error => {
      *    // Any status codes that falls outside the range of 2xx cause this function to trigger
      *    // Do something with response error
-     *    return Promise.reject(error);
-     * });
+     *    return Promise.reject(error)
+     * })
      * @example <caption>Removing Interceptors</caption>
-     * const myInterceptor = api.interceptors.request.use(function () {...});
-     * api.interceptors.request.eject(myInterceptor);
+     * const myInterceptor = api.interceptors.request.use(function () {...})
+     * api.interceptors.request.eject(myInterceptor)
      */
     this.interceptors = this.axios.interceptors
   }

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -77,6 +77,7 @@ export default class Kitsu {
     this.update = this.patch
     this.create = this.post
     this.remove = this.delete
+    this.interceptors = this.axios.interceptors
   }
 
   /**

--- a/packages/kitsu/src/index.spec.js
+++ b/packages/kitsu/src/index.spec.js
@@ -19,6 +19,11 @@ describe('kitsu', () => {
       expect.assertions(1)
       expect(api.create).toEqual(api.post)
     })
+
+    it('aliases interceptors to axios.interceptors', () => {
+      expect.assertions(1)
+      expect(api.interceptors).toEqual(api.axios.interceptors)
+    })
   })
 
   describe('class constructor', () => {


### PR DESCRIPTION
Solves #132 

This should allow access to the axios interceptors functionality via the base Kitsu class.  Thus creating similar usage as the axios documentation, but on the Kitsu object.