### PR TITLE
fix(kitsu-core): allow longer prototype chain on serialise

### DIFF
--- a/packages/kitsu-core/src/serialise/index.js
+++ b/packages/kitsu-core/src/serialise/index.js
@@ -24,7 +24,7 @@ function isValid (isArray, type, payload, method) {
       }
     }
   } else {
-    if (payload?.constructor !== Object || Object.keys(payload).length === 0) {
+    if (typeof payload !== 'object' || Object.keys(payload).length === 0) {
       throw new Error(`${method} requires an object or array body`)
     }
     // A POST request is the only request to not require an ID in spec


### PR DESCRIPTION
Re-opening due to a premature merge!

Thanks for the awesome library.

I'm currently using it in a TypeScript project with instantiated objects of a different type (i.e., const user = new User()). The validation that checks the object's prototype parent fails unless I clone the object (by passing in something like { ...user }). I changed the validation to allow objects further down the prototype chain.

Let me know if I'm missing the justification. Thanks again for your time.