### PR TITLE
build: drop node 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This is a monorepo containing the following packages:
 
 | Package      | Package<br> Size\* | Node | Chrome | Firefox | Safari | Edge |
 | -----------: | :----------------: | :--: | :----: | :-----: | :----: | :--: |
-| `kitsu`      | ≤ 8.2 kb           | 10+  | 69+    | 68+     | 12+    | 18+  |
-| `kitsu-core` | ≤ 1.6 kb           | 10+  | 69+    | 68+     | 12+    | 18+  |
+| `kitsu`      | ≤ 8.2 kb           | 12+  | 69+    | 68+     | 12+    | 18+  |
+| `kitsu-core` | ≤ 1.6 kb           | 12+  | 69+    | 68+     | 12+    | 18+  |
 
 \* Including all dependencies & minified with brotli
 

--- a/config/presets.js
+++ b/config/presets.js
@@ -1,4 +1,4 @@
-const minNode = 10
+const minNode = 12
 const mainBrowsers = [
   'last 2 years',
   'not < 0.05%'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wopian/kitsu/issues"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "workspaces": [
     "packages/*"

--- a/packages/kitsu-core/README.md
+++ b/packages/kitsu-core/README.md
@@ -38,7 +38,7 @@
 
 |      Package | Package<br> Size\* | ESM Size† | Node | Chrome | Firefox | Safari | Edge |
 | -----------: | :----------------: | :-------: | :--: | :----: | :-----: | :----: | :--: |
-| `kitsu-core` |      ≤ 1.5 kb      |  ≤ 1.3 KB |  10+ |   69+  |   68+   |   12+  |  18+ |
+| `kitsu-core` |      ≤ 1.5 kb      |  ≤ 1.3 KB |  12+ |   69+  |   68+   |   12+  |  18+ |
 
 \* Minified with brotli
 † EcmaScript Modules package size\*

--- a/packages/kitsu-core/package.json
+++ b/packages/kitsu-core/package.json
@@ -23,7 +23,7 @@
   },
   "funding": "https://github.com/sponsors/wopian",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "keywords": [
     "kitsu",

--- a/packages/kitsu/README.md
+++ b/packages/kitsu/README.md
@@ -37,7 +37,7 @@
 
 | Package | Package<br> Size\* | ESM Size† | Node | Chrome | Firefox | Safari | Edge |
 | ------: | :----------------: | :-------: | :--: | :----: | :-----: | :----: | :--: |
-| `kitsu` |      ≤ 8.6 kb      |  ≤ 8.4 KB |  10+ |   69+  |   68+   |   12+  |  18+ |
+| `kitsu` |      ≤ 8.6 kb      |  ≤ 8.4 KB |  12+ |   69+  |   68+   |   12+  |  18+ |
 
 \* Including all dependencies & minified with brotli
 † EcmaScript Modules package size\*

--- a/packages/kitsu/package.json
+++ b/packages/kitsu/package.json
@@ -21,7 +21,7 @@
   },
   "funding": "https://github.com/sponsors/wopian",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "keywords": [
     "kitsu",


### PR DESCRIPTION
Applies to `^10.x` only (currently pre-release) - `^9.x` will retain node 10 support

Node 10 is in the last stages of Maintenance LTS and will hit EOL in April 2021