### PR TITLE
Revert "build: update amancevice/setup-code-climate action to v1"

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install Code Climate test reporter
       if: matrix.node_version == 14 && matrix.os == 'ubuntu-latest'
-      uses: amancevice/setup-code-climate@v1
+      uses: amancevice/setup-code-climate@v0
       with:
         cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
 


### PR DESCRIPTION
Reverts wopian/kitsu#492

Release was removed from GitHub and now breaks CI builds (see https://github.com/wopian/kitsu/pull/493)