### PR TITLE
build: don't run output through terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "rollup": "~2.15.0",
     "rollup-plugin-delete": "~2.0.0",
     "rollup-plugin-local-resolve": "~1.0.7",
-    "rollup-plugin-terser": "~6.1.0",
     "size-limit": "~4.5.0",
     "typescript": "~3.9.3"
   },

--- a/packages/kitsu-core/rollup.config.js
+++ b/packages/kitsu-core/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from '@rollup/plugin-babel'
-import { terser } from 'rollup-plugin-terser'
 import local from 'rollup-plugin-local-resolve'
 import del from 'rollup-plugin-delete'
 import pkg from './package.json'
@@ -19,8 +18,7 @@ const globals = {
 }
 
 const plugins = [
-  local(),
-  terser()
+  local()
 ]
 
 const pluginsMain = [

--- a/packages/kitsu/rollup.config.js
+++ b/packages/kitsu/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from '@rollup/plugin-babel'
-import { terser } from 'rollup-plugin-terser'
 import local from 'rollup-plugin-local-resolve'
 import del from 'rollup-plugin-delete'
 import pkg from './package.json'
@@ -24,8 +23,7 @@ const globals = {
 
 const plugins = [
   del({ targets: './lib/*' }),
-  local(),
-  terser()
+  local()
 ]
 
 const pluginsMain = [


### PR DESCRIPTION
Most modern bundlers do this now on the client-end so zero change to final size, while making life far easier for debugging.