### PR TITLE
build: drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [12, 14, 16]
+        node_version: [14, 16, 18]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [16]
+        node_version: [18]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This is a monorepo containing the following packages:
 
 |      Package | Package<br> Size\* | Node | Chrome | Firefox | Safari | Edge |
 | -----------: | :----------------: | :--: | :----: | :-----: | :----: | :--: |
-|      `kitsu` |      ≤ 8.2 kb      | 12+  |  83+   |   78+   | 13.1+  | 95+  |
-| `kitsu-core` |      ≤ 1.6 kb      | 12+  |  83+   |   78+   | 13.1+  | 95+  |
+|      `kitsu` |      ≤ 8.2 kb      | 14+  |  83+   |   78+   | 13.1+  | 95+  |
+| `kitsu-core` |      ≤ 1.6 kb      | 14+  |  83+   |   78+   | 13.1+  | 95+  |
 
 \* Including all dependencies & minified with brotli
 

--- a/config/presets.js
+++ b/config/presets.js
@@ -1,4 +1,4 @@
-const minNode = 12
+const minNode = 14
 const mainBrowsers = [
   'last 2 years',
   'not < 0.05%'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/wopian/kitsu/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "workspaces": [
     "packages/*"

--- a/packages/kitsu-core/README.md
+++ b/packages/kitsu-core/README.md
@@ -38,7 +38,7 @@
 
 |      Package | Package<br> Size\* | ESM Size† | Node | Chrome | Firefox | Safari | Edge |
 | -----------: | :----------------: | :-------: | :--: | :----: | :-----: | :----: | :--: |
-| `kitsu-core` |      ≤ 1.5 kb      | ≤ 1.4 KB  | 12+  |  83+   |   78+   | 13.1+  | 95+  |
+| `kitsu-core` |      ≤ 1.5 kb      | ≤ 1.4 KB  | 14+  |  83+   |   78+   | 13.1+  | 95+  |
 
 \* Minified with brotli
 † EcmaScript Modules package size\*

--- a/packages/kitsu-core/package.json
+++ b/packages/kitsu-core/package.json
@@ -23,7 +23,7 @@
   },
   "funding": "https://github.com/sponsors/wopian",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "keywords": [
     "kitsu",

--- a/packages/kitsu/README.md
+++ b/packages/kitsu/README.md
@@ -37,7 +37,7 @@
 
 | Package | Package<br> Size\* | ESM Size† | Node | Chrome | Firefox | Safari | Edge |
 | ------: | :----------------: | :-------: | :--: | :----: | :-----: | :----: | :--: |
-| `kitsu` |      ≤ 8.7 kb      | ≤ 8.6 KB  | 12+  |  83+   |   78+   | 13.1+  | 95+  |
+| `kitsu` |      ≤ 8.7 kb      | ≤ 8.6 KB  | 14+  |  83+   |   78+   | 13.1+  | 95+  |
 
 \* Including all dependencies & minified with brotli
 † EcmaScript Modules package size\*

--- a/packages/kitsu/package.json
+++ b/packages/kitsu/package.json
@@ -21,7 +21,7 @@
   },
   "funding": "https://github.com/sponsors/wopian",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "keywords": [
     "kitsu",


### PR DESCRIPTION
Node 12 reaches end of life at the end of April 2022. Library is now tested with Node 14, 16 and 18.