### PR TITLE
fix(kitsu-core): fix deserialisation of relationships from primary data

### DIFF
--- a/packages/kitsu-core/src/deserialise/index.js
+++ b/packages/kitsu-core/src/deserialise/index.js
@@ -10,8 +10,7 @@ import { linkRelationships } from '../linkRelationships'
  */
 function deserialiseArray (array) {
   for (let value of array.data) {
-    if (array.included) value = linkRelationships(value, array.included)
-    if (value.relationships) value = linkRelationships(value)
+    value = linkRelationships(value, [ ...array.data, ...(array.included || []) ])
     if (value.attributes) value = deattribute(value)
     array.data[array.data.indexOf(value)] = value
   }

--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -670,5 +670,122 @@ describe('kitsu-core', () => {
         ]
       })
     })
+
+    it('deserialises a relationship from the data key', () => {
+      expect.assertions(1)
+
+      const input = deserialise({
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            attributes: { name: 'A' },
+            relationships: {
+              prequel: {
+                data: {
+                  type: 'anime',
+                  id: '42'
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            attributes: { name: 'B' },
+            relationships: {
+              prequel: {
+                data: {
+                  type: 'anime',
+                  id: '1'
+                }
+              }
+            }
+          },
+          {
+            id: '3',
+            type: 'anime',
+            attributes: { name: 'C' },
+            relationships: {
+              prequel: {
+                data: {
+                  type: 'anime',
+                  id: '4'
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            id: '4',
+            type: 'anime',
+            attributes: { name: 'D' },
+            relationships: {
+              prequel: {
+                data: {
+                  type: 'anime',
+                  id: '42'
+                }
+              }
+            }
+          }
+        ]
+      })
+
+      const output = {
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            name: 'A',
+            prequel: {
+              data: {
+                id: '42',
+                type: 'anime'
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            name: 'B',
+            prequel: {
+              data: {
+                id: '1',
+                type: 'anime',
+                name: 'A',
+                prequel: {
+                  data: {
+                    id: '42',
+                    type: 'anime'
+                  }
+                }
+              }
+            }
+          },
+          {
+            id: '3',
+            type: 'anime',
+            name: 'C',
+            prequel: {
+              data: {
+                id: '4',
+                type: 'anime',
+                name: 'D',
+                prequel: {
+                  data: {
+                    id: '42',
+                    type: 'anime'
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+
+      expect(input).toEqual(output)
+    })
   })
 })


### PR DESCRIPTION
I ran into this issue where resource relationships would not deserialise correctly, due to being removed from `includes`.
According to the git history of AMS, this is inteded behaviour https://github.com/rails-api/active_model_serializers/commit/f4bb4c81b0a7925104fd55143cd6f888de667fc6

It seems to be described by this line in the jsonapi spec:
`A compound document MUST NOT include more than one resource object for each type and id pair.`
(more on the topic https://discuss.jsonapi.org/t/why-is-included-an-array/76/4)

With this very minor change, this edge-case should be handled correctly.
