### PR TITLE
fix(kitsu-core): fix inability to link relationship links on circular resources

### DIFF
--- a/packages/kitsu-core/src/deserialise/index.js
+++ b/packages/kitsu-core/src/deserialise/index.js
@@ -10,8 +10,9 @@ import { linkRelationships } from '../linkRelationships'
  */
 function deserialiseArray (array) {
   const previouslyLinked = {}
+  const relationshipCache = {}
   for (let value of array.data) {
-    value = linkRelationships(value, [ ...array.data, ...(array.included || []) ], previouslyLinked)
+    value = linkRelationships(value, [ ...array.data, ...(array.included || []) ], previouslyLinked, relationshipCache)
     if (value.attributes) value = deattribute(value)
     array.data[array.data.indexOf(value)] = value
   }

--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -1,4 +1,5 @@
 import { deserialise } from './'
+import stringify from 'json-stringify-safe'
 
 describe('kitsu-core', () => {
   describe('deserialise', () => {
@@ -776,6 +777,156 @@ describe('kitsu-core', () => {
                   data: {
                     id: '42',
                     type: 'anime'
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+
+      expect(input).toEqual(output)
+    })
+
+    it('Deserializes nested single circular resource', () => {
+      expect.assertions(1)
+
+      const input = JSON.parse(stringify(deserialise({
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            attributes: { name: 'A' },
+            relationships: {
+              user: {
+                data: {
+                  id: '1',
+                  type: 'users'
+                },
+                links: {
+                  self: 'https://kitsu.example/user',
+                  related: 'https://kitsu.example/user'
+                },
+                meta: {
+                  hello: 'world'
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            attributes: { name: 'B' },
+            relationships: {
+              user: {
+                data: {
+                  id: '1',
+                  type: 'users'
+                }
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            id: '1',
+            type: 'users',
+            attributes: { name: 'B' },
+            relationships: {
+              favorite_anime: {
+                data: {
+                  id: '1',
+                  type: 'anime'
+                },
+                links: {
+                  self: 'https://kitsu.example/favorite_anime',
+                  related: 'https://kitsu.example/favorite_anime'
+                },
+                meta: {
+                  test: '123123'
+                }
+              }
+            }
+          }
+        ]
+      })))
+
+      const output = {
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            name: 'A',
+            user: {
+              links: {
+                self: 'https://kitsu.example/user',
+                related: 'https://kitsu.example/user'
+              },
+              meta: {
+                hello: 'world'
+              },
+              data: {
+                id: '1',
+                type: 'users',
+                name: 'B',
+                favorite_anime: {
+                  meta: {
+                    test: '123123'
+                  },
+                  links: {
+                    self: 'https://kitsu.example/favorite_anime',
+                    related: 'https://kitsu.example/favorite_anime'
+                  },
+                  data: {
+                    id: '1',
+                    type: 'anime',
+                    name: 'A',
+                    user: {
+                      meta: {
+                        hello: 'world'
+                      },
+                      data: '[Circular ~.data.0.user.data]',
+                      links: {
+                        self: 'https://kitsu.example/user',
+                        related: 'https://kitsu.example/user'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            name: 'B',
+            user: {
+              data: {
+                id: '1',
+                type: 'users',
+                name: 'B',
+                favorite_anime: {
+                  meta: {
+                    test: '123123'
+                  },
+                  links: {
+                    self: 'https://kitsu.example/favorite_anime',
+                    related: 'https://kitsu.example/favorite_anime'
+                  },
+                  data: {
+                    id: '1',
+                    type: 'anime',
+                    name: 'A',
+                    user: {
+                      meta: {
+                        hello: 'world'
+                      },
+                      data: '[Circular ~.data.1.user.data]',
+                      links: {
+                        self: 'https://kitsu.example/user',
+                        related: 'https://kitsu.example/user'
+                      }
+                    }
                   }
                 }
               }

--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -937,5 +937,169 @@ describe('kitsu-core', () => {
 
       expect(input).toEqual(output)
     })
+
+    it('Deserializes nested array circular resource', () => {
+      expect.assertions(1)
+
+      const input = JSON.parse(stringify(deserialise({
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            attributes: { name: 'A' },
+            relationships: {
+              users: {
+                data: [
+                  {
+                    id: '1',
+                    type: 'users'
+                  }
+                ],
+                links: {
+                  self: 'https://kitsu.example/user',
+                  related: 'https://kitsu.example/user'
+                },
+                meta: {
+                  hello: 'world'
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            attributes: { name: 'B' },
+            relationships: {
+              users: {
+                data: [
+                  {
+                    id: '1',
+                    type: 'users'
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            id: '1',
+            type: 'users',
+            attributes: { name: 'B' },
+            relationships: {
+              favorite_anime: {
+                data: [
+                  {
+                    id: '1',
+                    type: 'anime'
+                  }
+                ],
+                links: {
+                  self: 'https://kitsu.example/favorite_anime',
+                  related: 'https://kitsu.example/favorite_anime'
+                },
+                meta: {
+                  test: '123123'
+                }
+              }
+            }
+          }
+        ]
+      })))
+
+      const output = {
+        data: [
+          {
+            id: '1',
+            type: 'anime',
+            name: 'A',
+            users: {
+              links: {
+                self: 'https://kitsu.example/user',
+                related: 'https://kitsu.example/user'
+              },
+              meta: {
+                hello: 'world'
+              },
+              data: [
+                {
+                  id: '1',
+                  type: 'users',
+                  name: 'B',
+                  favorite_anime: {
+                    meta: {
+                      test: '123123'
+                    },
+                    links: {
+                      self: 'https://kitsu.example/favorite_anime',
+                      related: 'https://kitsu.example/favorite_anime'
+                    },
+                    data: [
+                      {
+                        id: '1',
+                        type: 'anime',
+                        name: 'A',
+                        users: {
+                          meta: {
+                            hello: 'world'
+                          },
+                          data: [ '[Circular ~.data.0.users.data.0]' ],
+                          links: {
+                            self: 'https://kitsu.example/user',
+                            related: 'https://kitsu.example/user'
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            id: '2',
+            type: 'anime',
+            name: 'B',
+            users: {
+              data: [
+                {
+                  id: '1',
+                  type: 'users',
+                  name: 'B',
+                  favorite_anime: {
+                    meta: {
+                      test: '123123'
+                    },
+                    links: {
+                      self: 'https://kitsu.example/favorite_anime',
+                      related: 'https://kitsu.example/favorite_anime'
+                    },
+                    data: [
+                      {
+                        id: '1',
+                        type: 'anime',
+                        name: 'A',
+                        users: {
+                          meta: {
+                            hello: 'world'
+                          },
+                          data: [ '[Circular ~.data.1.users.data.0]' ],
+                          links: {
+                            self: 'https://kitsu.example/user',
+                            related: 'https://kitsu.example/user'
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      expect(input).toEqual(output)
+    })
   })
 })

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -72,8 +72,8 @@ function linkObject (data, included, key, previouslyLinked, relationshipCache) {
   const relationships = relationshipCache[cacheKey] || data.relationships[key]
   if (!relationshipCache[cacheKey]) relationshipCache[cacheKey] = relationships
 
-  if (relationships && relationships.links) data[key].links = relationships.links
-  if (relationships && relationships.meta) data[key].meta = relationships.meta
+  if (relationships?.links) data[key].links = relationships.links
+  if (relationships?.meta) data[key].meta = relationships.meta
 
   delete data.relationships[key]
 }

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -39,6 +39,7 @@ function linkArray (data, included, key, previouslyLinked, relationshipCache) {
   data[key] = {}
 
   if (data.relationships[key].links) data[key].links = data.relationships[key].links
+  if (data.relationships[key].meta) data[key].meta = data.relationships[key].meta
 
   data[key].data = []
 

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -68,8 +68,9 @@ function linkObject (data, included, key, previouslyLinked, relationshipCache) {
   const cache = previouslyLinked[`${resource.type}#${resource.id}`]
   data[key].data = cache || link(resource, included, previouslyLinked, relationshipCache)
 
-  const relationships = relationshipCache[`${data.type}#${data.id}#${key}`] || data.relationships[key]
-  if (!relationshipCache[`${data.type}#${data.id}#${key}`]) relationshipCache[`${data.type}#${data.id}#${key}`] = relationships
+  const cacheKey = `${data.type}#${data.id}#${key}`
+  const relationships = relationshipCache[cacheKey] || data.relationships[key]
+  if (!relationshipCache[cacheKey]) relationshipCache[cacheKey] = relationships
 
   if (relationships && relationships.links) data[key].links = relationships.links
   if (relationships && relationships.meta) data[key].meta = relationships.meta

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -9,15 +9,16 @@ import { filterIncludes } from '../filterIncludes'
  * @param {string} resource.type Resource type
  * @param {Object} [resource.meta] Meta information
  * @param {Object[]} included The response included object
- * @param {Object} [previouslyLinked] A mapping of already visited resources
+ * @param {Object} previouslyLinked A mapping of already visited resources
+ * @param {Object} relationshipCache A cache object for relationship meta and links
  * @private
  */
-function link ({ id, type, meta }, included, previouslyLinked) {
+function link ({ id, type, meta }, included, previouslyLinked, relationshipCache) {
   const filtered = filterIncludes(included, { id, type })
   previouslyLinked[`${type}#${id}`] = filtered
 
   if (filtered.relationships) {
-    linkRelationships(filtered, included, previouslyLinked)
+    linkRelationships(filtered, included, previouslyLinked, relationshipCache)
   }
   if (meta) filtered.meta = meta
 
@@ -31,9 +32,10 @@ function link ({ id, type, meta }, included, previouslyLinked) {
  * @param {Object[]} included The response included object
  * @param {string} key Name of the relationship item
  * @param {Object} previouslyLinked A mapping of already visited resources
+ * @param {Object} relationshipCache A cache object for relationship meta and links
  * @private
  */
-function linkArray (data, included, key, previouslyLinked) {
+function linkArray (data, included, key, previouslyLinked, relationshipCache) {
   data[key] = {}
 
   if (data.relationships[key].links) data[key].links = data.relationships[key].links
@@ -42,7 +44,7 @@ function linkArray (data, included, key, previouslyLinked) {
 
   for (const resource of data.relationships[key].data) {
     const cache = previouslyLinked[`${resource.type}#${resource.id}`]
-    let relationship = cache || link(resource, included, previouslyLinked)
+    let relationship = cache || link(resource, included, previouslyLinked, relationshipCache)
     if (resource.meta !== relationship.meta) relationship = { ...relationship, meta: resource.meta }
     data[key].data.push(relationship)
   }
@@ -57,14 +59,21 @@ function linkArray (data, included, key, previouslyLinked) {
  * @param {Object[]} included The response included object
  * @param {string} key Name of the relationship item
  * @param {Object} previouslyLinked A mapping of already visited resources
+ * @param {Object} relationshipCache A cache object for relationship meta and links
  * @private
  */
-function linkObject (data, included, key, previouslyLinked) {
+function linkObject (data, included, key, previouslyLinked, relationshipCache) {
   data[key] = {}
   const resource = data.relationships[key].data
   const cache = previouslyLinked[`${resource.type}#${resource.id}`]
-  data[key].data = cache || link(resource, included, previouslyLinked)
-  if (data.relationships[key].links) data[key].links = data.relationships[key].links
+  data[key].data = cache || link(resource, included, previouslyLinked, relationshipCache)
+
+  const relationships = relationshipCache[`${data.type}#${data.id}#${key}`] || data.relationships[key]
+  if (!relationshipCache[`${data.type}#${data.id}#${key}`]) relationshipCache[`${data.type}#${data.id}#${key}`] = relationships
+
+  if (relationships && relationships.links) data[key].links = relationships.links
+  if (relationships && relationships.meta) data[key].meta = relationships.meta
+
   delete data.relationships[key]
 }
 
@@ -87,6 +96,7 @@ function linkAttr (data, key) {
  * @param {Object} data The response data object
  * @param {Object[]} [included] The response included object
  * @param {Object} [previouslyLinked] A mapping of already visited resources (internal use only)
+ * @param {Object} [relationshipCache] A cache object for relationship meta and links
  * @returns Parsed data
  *
  * @example
@@ -111,16 +121,16 @@ function linkAttr (data, key) {
  * //   }
  * // }
  */
-export function linkRelationships (data, included = [], previouslyLinked = {}) {
+export function linkRelationships (data, included = [], previouslyLinked = {}, relationshipCache = {}) {
   const { relationships } = data
 
   for (const key in relationships) {
     // Relationship contains collection of resources
     if (Array.isArray(relationships[key]?.data)) {
-      linkArray(data, included, key, previouslyLinked)
+      linkArray(data, included, key, previouslyLinked, relationshipCache)
     // Relationship contains a single resource
     } else if (relationships[key].data) {
-      linkObject(data, included, key, previouslyLinked)
+      linkObject(data, included, key, previouslyLinked, relationshipCache)
     } else {
       linkAttr(data, key)
     }


### PR DESCRIPTION
Before this fix, this error would occasionally pop up
```
    TypeError: Cannot read properties of undefined (reading 'links')

      65 |   const cache = previouslyLinked[`${resource.type}#${resource.id}`]
      66 |   data[key].data = cache || link(resource, included, previouslyLinked)
    > 67 |   if (data.relationships[key].links) data[key].links = data.relationships[key].links
         |                               ^
      68 |   delete data.relationships[key]
      69 | }
      70 |

      at links (packages/kitsu-core/src/linkRelationships/index.js:67:31)
      at linkObject (packages/kitsu-core/src/linkRelationships/index.js:123:7)
      at deserialiseArray (packages/kitsu-core/src/deserialise/index.js:14:13)
      at deserialiseArray (packages/kitsu-core/src/deserialise/index.js:61:48)
      at Object.<anonymous> (packages/kitsu-core/src/deserialise/index.spec.js:795:42)
```
When serializing a resource with a once removed relationship to itself (A -> B -> A).
The problem seems to stem from same origin as this issue https://github.com/wopian/kitsu/issues/579, where a `relationships` object is deleted before subsequent objects with references to it has had a change to read it

The simple solution would be to add safe navigation to the `if` statement, but then `meta` and `links` would be lost on any subsequent inclusions of the resource.

I was unable to reproduce this issue with array resource linkages, so only `linkObject` was modified. I have a feeling it might be due to something relating to pass-by-value/pass-by-reference. I wrote a spec for it, and it passed without modification, so i just removed it again. I can add it back if you think it would be relevant

I'm very open to style changes or suggestions for alternate implementations