### PR TITLE
ci: update renovate config to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "renovate": {
     "extends": [
-      "@wopian",
+      "github>wopian/renovate-config",
       ":pathSemanticCommitType(packages/kitsu/**,build(kitsu))",
       ":pathSemanticCommitType(packages/kitsu-core/**,build(kitsu-core))"
     ]


### PR DESCRIPTION
Publishing config to npm is deprecated by Renovate