### PR TITLE
docs: list pedep as a contributor

### DIFF
--- a/packages/kitsu-core/package.json
+++ b/packages/kitsu-core/package.json
@@ -8,7 +8,8 @@
     "Daniel Skogly <daniel.skogly@protonmail.com>",
     "Lukas Erlacher <erlacher@in.tum.de>",
     "Matthew Dias <matthewdias@me.com>",
-    "Menthol <bennetteson@gmail.com>"
+    "Menthol <bennetteson@gmail.com>",
+    "pedep <pedep@users.noreply.github.com>"
   ],
   "license": "MIT",
   "main": "dist/index",

--- a/packages/kitsu/package.json
+++ b/packages/kitsu/package.json
@@ -8,7 +8,8 @@
     "Daniel Skogly <daniel.skogly@protonmail.com>",
     "Lukas Erlacher <erlacher@in.tum.de>",
     "Matthew Dias <matthewdias@me.com>",
-    "Menthol <bennetteson@gmail.com>"
+    "Menthol <bennetteson@gmail.com>",
+    "pedep <pedep@users.noreply.github.com>"
   ],
   "license": "MIT",
   "main": "dist/index",


### PR DESCRIPTION
If you wish to be listed on the npm package page @pedep for your multiple contributions 🥇 


Edit: Actually looks like npm no longer reads the `contributors` entry, npm only shows myself these days 🤔 