### PR TITLE
fix(kitsu-core): prevent relationship mutation during multi-circular deserialisation

### DIFF
--- a/packages/kitsu-core/src/deserialise/index.js
+++ b/packages/kitsu-core/src/deserialise/index.js
@@ -12,7 +12,11 @@ function deserialiseArray (array) {
   const previouslyLinked = {}
   const relationshipCache = {}
   for (let value of array.data) {
-    value = linkRelationships(value, [ ...array.data, ...(array.included || []) ], previouslyLinked, relationshipCache)
+    const included = [
+      ...array.data.map(item => ({ ...item, relationships: { ...item.relationships } })),
+      ...(array.included || [])
+    ]
+    value = linkRelationships(value, included, previouslyLinked, relationshipCache)
     if (value.attributes) value = deattribute(value)
     array.data[array.data.indexOf(value)] = value
   }

--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -1102,4 +1102,149 @@ describe('kitsu-core', () => {
       expect(input).toEqual(output)
     })
   })
+
+  it('Deserializes first level resources after being serialized as a relationship', () => {
+    expect.assertions(1)
+
+    const input = JSON.parse(stringify(deserialise({
+      data: [
+        {
+          id: '5',
+          type: 'articles',
+          attributes: { title: 'asd0' },
+          relationships: {
+            author: {
+              data: {
+                id: '11',
+                type: 'authors'
+              },
+              links: { self: 'http://kitsu.example.com/authors' },
+              meta: { authors: 'articles#5' }
+            }
+          }
+        },
+        {
+          id: '6',
+          type: 'articles',
+          attributes: { title: 'asd1' },
+          relationships: {
+            author: {
+              data: {
+                id: '11',
+                type: 'authors'
+              },
+              links: { self: 'http://kitsu.example.com/authors' },
+              meta: { authors: 'articles#6' }
+            }
+          }
+        }
+      ],
+      included: [
+        {
+          id: '11',
+          type: 'authors',
+          attributes: { first_name: 'Egon', last_name: 'Egonsen' },
+          relationships: {
+            articles: {
+              data: [
+                {
+                  id: '5',
+                  type: 'articles'
+                },
+                {
+                  id: '6',
+                  type: 'articles'
+                }
+              ]
+            }
+          }
+        }
+      ]
+    })))
+
+    const output = {
+      data: [
+        {
+          id: '5',
+          type: 'articles',
+          title: 'asd0',
+          author: {
+            links: { self: 'http://kitsu.example.com/authors' },
+            meta: { authors: 'articles#5' },
+            data: {
+              id: '11',
+              type: 'authors',
+              first_name: 'Egon',
+              last_name: 'Egonsen',
+              articles: {
+                data: [
+                  {
+                    id: '5',
+                    type: 'articles',
+                    title: 'asd0',
+                    author: {
+                      data: '[Circular ~.data.0.author.data]',
+                      links: { self: 'http://kitsu.example.com/authors' },
+                      meta: { authors: 'articles#5' }
+                    }
+                  },
+                  {
+                    id: '6',
+                    type: 'articles',
+                    title: 'asd1',
+                    author: {
+                      data: '[Circular ~.data.0.author.data]',
+                      links: { self: 'http://kitsu.example.com/authors' },
+                      meta: { authors: 'articles#6' }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          id: '6',
+          type: 'articles',
+          title: 'asd1',
+          author: {
+            links: { self: 'http://kitsu.example.com/authors' },
+            meta: { authors: 'articles#6' },
+            data: {
+              id: '11',
+              type: 'authors',
+              first_name: 'Egon',
+              last_name: 'Egonsen',
+              articles: {
+                data: [
+                  {
+                    id: '5',
+                    type: 'articles',
+                    title: 'asd0',
+                    author: {
+                      data: '[Circular ~.data.1.author.data]',
+                      links: { self: 'http://kitsu.example.com/authors' },
+                      meta: { authors: 'articles#5' }
+                    }
+                  },
+                  {
+                    id: '6',
+                    type: 'articles',
+                    title: 'asd1',
+                    author: {
+                      data: '[Circular ~.data.1.author.data]',
+                      links: { self: 'http://kitsu.example.com/authors' },
+                      meta: { authors: 'articles#6' }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    expect(input).toEqual(output)
+  })
 })


### PR DESCRIPTION
This issue specifically occours if Article1 and Article2 are deserialized in primary data, but also
references directly by a relationship of Article1, such as Author1

This makes Article1 deserialize first, then its relationship Author1 is
deserialised, along with its relationships Article1 and Article 2

Once the entire chain is complete in Article1, Article2 is deserialised
in the main data, but due to being mutated by the prior deserialisation,
it has no items in its relationships key

~~Honestly im kind of stumped by this one. I'm attempting a minor rewrite to use
immutable/functional style, but that would have a pretty major impact on the rest of kitsu-core.~~

Having spent a day with the issue, and trying some dark redux-style magick with no success, the solution turned out a lot simpler than i would have initially guessed