### PR TITLE
fix(kitsu-core): deserialize meta only relationships

### DIFF
--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -187,6 +187,33 @@ describe('kitsu-core', () => {
       })
     })
 
+    it('deserialises relationships with meta', () => {
+      expect.assertions(1)
+      expect(deserialise({
+        data: {
+          id: '1',
+          type: 'users',
+          relationships: {
+            followers: {
+              meta: {
+                follower_count: 200
+              }
+            }
+          }
+        }
+      })).toEqual({
+        data: {
+          id: '1',
+          type: 'users',
+          followers: {
+            meta: {
+              follower_count: 200
+            }
+          }
+        }
+      })
+    })
+
     it('deserialises relationships with links and data (array)', () => {
       expect.assertions(1)
 

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -89,6 +89,7 @@ function linkObject (data, included, key, previouslyLinked, relationshipCache) {
 function linkAttr (data, key) {
   data[key] = {}
   if (data.relationships[key].links) data[key].links = data.relationships[key].links
+  if (data.relationships[key].meta) data[key].meta = data.relationships[key].meta
   delete data.relationships[key]
 }
 


### PR DESCRIPTION
same as with links only: https://github.com/wopian/kitsu/blob/d261d4c161f69f98f3f354455a3cc73efddfab82/packages/kitsu-core/src/deserialise/index.spec.js#L161-L188

[Section 5.2.4 of documentation](https://jsonapi.org/format/#document-resource-object-relationships) states "A “relationship object” MUST contain at least one of the following: `links`, `data` or `meta`", so meta-only relationships should be just as valid as links only.

With this we PR support all cases.

The test-case for links, meta and data at the same time is handled indirectly by other specs, such as here:
https://github.com/wopian/kitsu/blob/d261d4c161f69f98f3f354455a3cc73efddfab82/packages/kitsu-core/src/deserialise/index.spec.js#L791-L852
