### PR TITLE
fix(kitsu-core): deserialize meta only relationships

### DIFF
--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -186,6 +186,33 @@ describe('kitsu-core', () => {
       })
     })
 
+    it('deserialises relationships with meta', () => {
+      expect.assertions(1)
+      expect(deserialise({
+        data: {
+          id: '1',
+          type: 'users',
+          relationships: {
+            followers: {
+              meta: {
+                follower_count: 200
+              }
+            }
+          }
+        }
+      })).toEqual({
+        data: {
+          id: '1',
+          type: 'users',
+          followers: {
+            meta: {
+              follower_count: 200
+            }
+          }
+        }
+      })
+    })
+
     it('deserialises relationships with links and data (array)', () => {
       expect.assertions(1)
 

--- a/packages/kitsu-core/src/linkRelationships/index.js
+++ b/packages/kitsu-core/src/linkRelationships/index.js
@@ -62,6 +62,7 @@ function linkObject (data, included, key) {
 function linkAttr (data, key) {
   data[key] = {}
   if (data.relationships[key].links) data[key].links = data.relationships[key].links
+  if (data.relationships[key].meta) data[key].meta = data.relationships[key].meta
   delete data.relationships[key]
 }
 


### PR DESCRIPTION
Backport of #727 for 9.x