### PR TITLE
fix(kitsu-core): build list queryparams

### DIFF
--- a/packages/kitsu-core/src/query/index.js
+++ b/packages/kitsu-core/src/query/index.js
@@ -7,7 +7,8 @@
  * @private
  */
 function queryFormat (value, key) {
-  if (value !== null && typeof value === 'object') return query(value, key)
+  if (value !== null && Array.isArray(value)) return value.map(v => queryFormat(v, `${key}[]`)).join('&')
+  else if (value !== null && typeof value === 'object') return query(value, key)
   else return encodeURIComponent(key) + '=' + encodeURIComponent(value)
 }
 

--- a/packages/kitsu-core/src/query/index.js
+++ b/packages/kitsu-core/src/query/index.js
@@ -7,7 +7,7 @@
  * @private
  */
 function queryFormat (value, key) {
-  if (value !== null && Array.isArray(value)) return value.map(v => queryFormat(v, `${key}[]`)).join('&')
+  if (value !== null && Array.isArray(value)) return value.map(v => queryFormat(v, key)).join('&')
   else if (value !== null && typeof value === 'object') return query(value, key)
   else return encodeURIComponent(key) + '=' + encodeURIComponent(value)
 }

--- a/packages/kitsu-core/src/query/index.spec.js
+++ b/packages/kitsu-core/src/query/index.spec.js
@@ -58,5 +58,23 @@ describe('kitsu-core', () => {
         }
       })).toEqual('fields%5Babc%5D%5Bdef%5D%5Bghi%5D%5Bjkl%5D=mno')
     })
+
+    it('builds list parameters', () => {
+      expect.assertions(1)
+      expect(query({
+        filter: {
+          id_in: [ 1, 2, 3 ]
+        }
+      })).toEqual('filter%5Bid_in%5D%5B%5D=1&filter%5Bid_in%5D%5B%5D=2&filter%5Bid_in%5D%5B%5D=3')
+    })
+
+    it('builds nested list parameters', () => {
+      expect.assertions(1)
+      expect(query({
+        filter: {
+          users: [ { id: 1, type: 'users' }, { id: 2, type: 'users' } ]
+        }
+      })).toEqual('filter%5Busers%5D%5B%5D%5Bid%5D=1&filter%5Busers%5D%5B%5D%5Btype%5D=users&filter%5Busers%5D%5B%5D%5Bid%5D=2&filter%5Busers%5D%5B%5D%5Btype%5D=users')
+    })
   })
 })

--- a/packages/kitsu-core/src/query/index.spec.js
+++ b/packages/kitsu-core/src/query/index.spec.js
@@ -65,7 +65,7 @@ describe('kitsu-core', () => {
         filter: {
           id_in: [ 1, 2, 3 ]
         }
-      })).toEqual('filter%5Bid_in%5D%5B%5D=1&filter%5Bid_in%5D%5B%5D=2&filter%5Bid_in%5D%5B%5D=3')
+      })).toEqual('filter%5Bid_in%5D=1&filter%5Bid_in%5D=2&filter%5Bid_in%5D=3')
     })
 
     it('builds nested list parameters', () => {
@@ -74,7 +74,7 @@ describe('kitsu-core', () => {
         filter: {
           users: [ { id: 1, type: 'users' }, { id: 2, type: 'users' } ]
         }
-      })).toEqual('filter%5Busers%5D%5B%5D%5Bid%5D=1&filter%5Busers%5D%5B%5D%5Btype%5D=users&filter%5Busers%5D%5B%5D%5Bid%5D=2&filter%5Busers%5D%5B%5D%5Btype%5D=users')
+      })).toEqual('filter%5Busers%5D%5Bid%5D=1&filter%5Busers%5D%5Btype%5D=users&filter%5Busers%5D%5Bid%5D=2&filter%5Busers%5D%5Btype%5D=users')
     })
   })
 })


### PR DESCRIPTION
I'm not sure this is the way you would prefer to serialize arrays by default, but i personally think its better than the current behaviour.

### Expected behaviour:
`query` serializes arrays the same way a regular `<select multiple>` would.`

e.g. both
```
<select name="filter[id_in][]" multiple>
  <option value="1" selected> New York </option>
  <option value="2" selected> Boston </option>
</select>
```
and
```
query({filter: {id_in: [1,2]}})
```
should result in the following query
```
filter[id_in][]=1&filter[id_in][]=2
# deserialized in Rails: {"filter"=>{"id_in"=>["1", "2"]}}
```

### Current behaviour:

```
query({filter: {id_in: [1,2]}})
```
results in this query:
```
filter[id_in][0]=1&filter[id_in][1]=2
# deserialized in Rails: {"filter"=>{"id_in"=>{"0"=>"1", "1"=>"2"}}}
```