### PR TITLE
fix(kitsu-core): Allow empty POST body

### DIFF
--- a/packages/kitsu-core/src/serialise/index.js
+++ b/packages/kitsu-core/src/serialise/index.js
@@ -24,7 +24,7 @@ function isValid (isArray, type, payload, method) {
       }
     }
   } else {
-    if (typeof payload !== 'object' || Object.keys(payload).length === 0) {
+    if (typeof payload !== 'object' || (method !== 'POST' && Object.keys(payload).length === 0)) {
       throw new Error(`${method} requires an object or array body`)
     }
     // A POST request is the only request to not require an ID in spec

--- a/packages/kitsu-core/src/serialise/index.spec.js
+++ b/packages/kitsu-core/src/serialise/index.spec.js
@@ -241,10 +241,20 @@ describe('kitsu-core', () => {
       })
     })
 
-    it('throws an error if obj is missing', () => {
+    it('does not throws an error if obj is missing when method is POST', () => {
       expect.assertions(1)
-      expect(() => serialise('post'))
-        .toThrowError('POST requires an object or array body')
+      const input = serialise('anime', { }, 'POST')
+      expect(input).toEqual({
+        data: {
+          type: 'anime'
+        }
+      })
+    })
+
+    it('throws an error if obj is missing when method is not POST', () => {
+      expect.assertions(1)
+      expect(() => serialise('post', {}, 'PATCH'))
+        .toThrowError('PATCH requires an object or array body')
     })
 
     it('throws an error if obj is not an Object', () => {

--- a/packages/kitsu/src/post.spec.js
+++ b/packages/kitsu/src/post.spec.js
@@ -91,14 +91,45 @@ describe('kitsu', () => {
       await expect(await api.post('anime', { id: 123456789, type: 'anime', name: 'Name' })).toBeUndefined()
     })
 
-    it('throws an error if missing a JSON object body', async () => {
-      expect.assertions(1)
+    it('throws an error if missing a valid JSON object body', async () => {
+      expect.assertions(2)
       const api = new Kitsu()
       try {
-        await api.post('posts')
+        await api.post('posts', 123)
       } catch (err) {
         expect(err.message).toEqual('POST requires an object or array body')
       }
+
+      try {
+        await api.post('posts', 'invalid body')
+      } catch (err) {
+        expect(err.message).toEqual('POST requires an object or array body')
+      }
+    })
+
+    it('sends data in request if missing a JSON object body', async () => {
+      expect.assertions(4)
+      const api = new Kitsu()
+      mock.onPost('/anime').reply(config => {
+        expect(JSON.parse(config.data)).toEqual({
+          data: { type: 'anime' }
+        })
+        return [ 200 ]
+      })
+      await expect(await api.post('anime')).toBeUndefined()
+      await expect(await api.post('anime', {})).toBeUndefined()
+    })
+
+    it('sends data in request if given empty JSON object in array body', async () => {
+      expect.assertions(2)
+      const api = new Kitsu()
+      mock.onPost('/anime').reply(config => {
+        expect(JSON.parse(config.data)).toEqual({
+          data: [ { type: 'anime' } ]
+        })
+        return [ 200 ]
+      })
+      await expect(await api.post('anime', [ {} ])).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
closes #800

Issue stems from `isValid` being run before `let data = { type }`, making the `isValid` function assume the payload is empty even though it is not.
The spec allows type-only post bodies https://jsonapi.org/format/#crud-creating

I decided to just add another check for `method == 'POST'`, rather than something like this:
```diff
function serialiseRootObject (type, payload, method, options) {
-  isValid(false, type, payload, method)
+  isValid(false, type, {...payload, type: type}, method)
  type = options.pluralTypes(options.camelCaseTypes(type))
  let data = { type }
```
since this change would the `${method} requires an ID for the ${type} type` error raise on empty PATCH bodies instead of `${method} requires an object or array body` error