### PR TITLE
fix(kitsu): update dependency axios to v0.28.1 to address CVE-2023-45857

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "~7.24.0",
     "@babel/preset-env": "~7.24.0",
     "@rollup/plugin-babel": "~6.0.0",
-    "axios": "~0.27.0",
+    "axios": "~0.28.1",
     "axios-mock-adapter": "~1.22.0",
     "babel-jest": "~29.7.0",
     "browserslist": "~4.23.0",

--- a/packages/kitsu/package.json
+++ b/packages/kitsu/package.json
@@ -49,19 +49,19 @@
     "build": "yarn rollup"
   },
   "dependencies": {
-    "axios": "^0.27.0",
+    "axios": "^0.28.1",
     "kitsu-core": "^10.1.4",
     "pluralize": "^8.0.0"
   },
   "size-limit": [
     {
       "path": "./dist/index.js",
-      "limit": "13 kb",
+      "limit": "14 kb",
       "brotli": true
     },
     {
       "path": "./dist/index.mjs",
-      "limit": "13 kb",
+      "limit": "14 kb",
       "brotli": true
     }
   ],

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -77,6 +77,7 @@ export default class Kitsu {
         baseURL: options.baseURL || 'https://kitsu.io/api/edge',
         timeout: options.timeout || 30000
       },
+      paramsSerializer: { serialize: /* istanbul ignore next */ p => this.query(p) },
       ...options.axiosOptions
     })
 
@@ -235,7 +236,6 @@ export default class Kitsu {
       const { data, headers: responseHeaders } = await this.axios.get(url, {
         headers,
         params,
-        paramsSerializer: /* istanbul ignore next */ p => this.query(p),
         ...config.axiosOptions
       })
 
@@ -298,7 +298,6 @@ export default class Kitsu {
         {
           headers,
           params,
-          paramsSerializer: /* istanbul ignore next */ p => this.query(p),
           ...config.axiosOptions
         }
       )
@@ -359,7 +358,6 @@ export default class Kitsu {
         {
           headers,
           params,
-          paramsSerializer: /* istanbul ignore next */ p => this.query(p),
           ...config.axiosOptions
         }
       )
@@ -414,7 +412,6 @@ export default class Kitsu {
         }),
         headers,
         params,
-        paramsSerializer: /* istanbul ignore next */ p => this.query(p),
         ...config.axiosOptions
       })
 
@@ -524,7 +521,6 @@ export default class Kitsu {
           }),
         headers: { ...this.headers, ...headers },
         params,
-        paramsSerializer: /* istanbul ignore next */ p => this.query(p),
         ...axiosOptions
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,13 +3067,14 @@ axios-mock-adapter@~1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@^0.27.0, axios@~0.27.0:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@^0.28.1, axios@~0.28.1:
+  version "0.28.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz#2a7bcd34a3837b71ee1a5ca3762214b86b703e70"
+  integrity sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0, babel-jest@~29.7.0:
   version "29.7.0"
@@ -5018,9 +5019,9 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.15.0:
   version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 for-each@^0.3.3:
@@ -8732,6 +8733,11 @@ protoduck@^5.0.1:
   integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
   dependencies:
     genfun "^5.0.0"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
Closes #978

This bumps axios to 0.28.1 due to [Axios Cross-Site Request Forgery Vulnerability](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx).
The `size-limit` needed to be adjusted from `13 kb` to `14 kb`
The `paramsSerializer` configuration needs to be an object with `serialize` set to the function.