### PR TITLE
fix: allow delete method request to send data

### DIFF
--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -513,7 +513,7 @@ export default class Kitsu {
       const { data, headers: responseHeaders } = await this.axios.request({
         method,
         url,
-        data: [ 'GET', 'DELETE' ].includes(method)
+        data: method === 'GET'
           ? undefined
           : serialise(type, body, method, {
             camelCaseTypes: this.camel,


### PR DESCRIPTION
Hello,

I think the `delete` method should be allowed to send data on `request` method