### PR TITLE
Add HTTP status code to kitsu responses

### DIFF
--- a/packages/kitsu/src/delete.spec.js
+++ b/packages/kitsu/src/delete.spec.js
@@ -35,7 +35,8 @@ describe('kitsu', () => {
       expect(await api.delete('anime', 1, { headers: { extra: true } })).toEqual({
         headers: {
           Accept: 'application/vnd.api+json'
-        }
+        },
+        statusCode: 200
       })
     })
 
@@ -51,7 +52,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('post', 1)).toBeUndefined()
+      await expect(await api.delete('post', 1)).toEqual({ statusCode: 200 })
     })
 
     it('handles nested routes', async () => {
@@ -66,7 +67,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('posts/1/comments', 1)).toBeUndefined()
+      await expect(await api.delete('posts/1/comments', 1)).toEqual({ statusCode: 200 })
     })
 
     it('deletes multiple resources (bulk extension)', async () => {
@@ -81,7 +82,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('post', [ 1, 2 ])).toBeUndefined()
+      await expect(await api.delete('post', [ 1, 2 ])).toEqual({ statusCode: 200 })
     })
 
     it('throws an error if ID is missing', async () => {

--- a/packages/kitsu/src/delete.spec.js
+++ b/packages/kitsu/src/delete.spec.js
@@ -36,7 +36,7 @@ describe('kitsu', () => {
         headers: {
           Accept: 'application/vnd.api+json'
         },
-        statusCode: 200
+        status: 200
       })
     })
 
@@ -52,7 +52,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('post', 1)).toEqual({ statusCode: 200 })
+      await expect(await api.delete('post', 1)).toEqual({ status: 200 })
     })
 
     it('handles nested routes', async () => {
@@ -67,7 +67,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('posts/1/comments', 1)).toEqual({ statusCode: 200 })
+      await expect(await api.delete('posts/1/comments', 1)).toEqual({ status: 200 })
     })
 
     it('deletes multiple resources (bulk extension)', async () => {
@@ -82,7 +82,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.delete('post', [ 1, 2 ])).toEqual({ statusCode: 200 })
+      await expect(await api.delete('post', [ 1, 2 ])).toEqual({ status: 200 })
     })
 
     it('throws an error if ID is missing', async () => {

--- a/packages/kitsu/src/get.spec.js
+++ b/packages/kitsu/src/get.spec.js
@@ -51,7 +51,7 @@ describe('kitsu', () => {
           'Content-Type': 'application/vnd.api+json',
           extra: true
         },
-        statusCode: 200
+        status: 200
       })
     })
 
@@ -60,7 +60,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('/anime').reply(200, getCollection.jsonapi)
       const request = await api.get('anime')
-      expect(request).toEqual({ ...getCollection.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getCollection.kitsu, status: 200 })
     })
 
     it('fetches a single resource', async () => {
@@ -68,7 +68,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet(`anime/${getSingle.jsonapi.data.id}`).reply(200, getSingle.jsonapi)
       const request = await api.get('anime/1')
-      expect(request).toEqual({ ...getSingle.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingle.kitsu, status: 200 })
     })
 
     it('fetches a relationship collection of resources', async () => {
@@ -76,7 +76,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('authors/1/anime').reply(200, getCollection.jsonapi)
       const request = await api.get('author/1/anime')
-      expect(request).toEqual({ ...getCollection.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getCollection.kitsu, status: 200 })
     })
 
     it('fetches a relationshop single resource', async () => {
@@ -84,7 +84,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('comments/1/anime').reply(200, getSingle.jsonapi)
       const request = await api.get('comment/1/anime')
-      expect(request).toEqual({ ...getSingle.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingle.kitsu, status: 200 })
     })
 
     it('fetches a collection of resources with includes', async () => {
@@ -92,7 +92,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime').reply(200, getCollectionWithIncludes.jsonapi)
       const request = await api.get('anime')
-      expect(request).toEqual({ ...getCollectionWithIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getCollectionWithIncludes.kitsu, status: 200 })
     })
 
     it('fetches a single resource with includes', async () => {
@@ -100,7 +100,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet(`anime/${getSingleWithIncludes.jsonapi.data.id}`, { include: 'author,comments' }).reply(200, getSingleWithIncludes.jsonapi)
       const request = await api.get('anime/1', { params: { include: 'author,comments' } })
-      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, status: 200 })
     })
 
     it('fetches a single resource with nested includes', async () => {
@@ -108,7 +108,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime/1').reply(200, getSingleWithNestedIncludes.jsonapi)
       const request = await api.get('anime/1')
-      expect(request).toEqual({ ...getSingleWithNestedIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingleWithNestedIncludes.kitsu, status: 200 })
     })
 
     it('fetches a single resource with a camelCase relationship include', async () => {
@@ -116,7 +116,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime/1', { params: { include: 'animeStaff' } }).reply(200, getSingleWithIncludes.jsonapi)
       const request = await api.get('anime/1', { params: { include: 'animeStaff' } })
-      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, status: 200 })
     })
 
     it('fetches :resource/:id/relationships/:relationship', async () => {
@@ -134,7 +134,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('media-relationships/1/relationships/destination').reply(200, response)
       const request = await api.get('mediaRelationships/1/relationships/destination')
-      expect(request).toEqual({ ...response, statusCode: 200 })
+      expect(request).toEqual({ ...response, status: 200 })
     })
 
     it('fetches :resource/:relationship/:subRelationship', async () => {
@@ -148,7 +148,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ pluralize: false })
       mock.onGet('profile/user-accounts/me').reply(200, response)
       const request = await api.get('profile/userAccounts/me')
-      expect(request).toEqual({ ...response, statusCode: 200 })
+      expect(request).toEqual({ ...response, status: 200 })
     })
 
     it('returns a JSON:API error object for invalid queries', async () => {
@@ -273,7 +273,7 @@ describe('kitsu', () => {
             }
           }
         ],
-        statusCode: 200
+        status: 200
       })
     })
   })

--- a/packages/kitsu/src/get.spec.js
+++ b/packages/kitsu/src/get.spec.js
@@ -50,7 +50,8 @@ describe('kitsu', () => {
           Accept: 'application/vnd.api+json',
           'Content-Type': 'application/vnd.api+json',
           extra: true
-        }
+        },
+        statusCode: 200
       })
     })
 
@@ -59,7 +60,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('/anime').reply(200, getCollection.jsonapi)
       const request = await api.get('anime')
-      expect(request).toEqual(getCollection.kitsu)
+      expect(request).toEqual({ ...getCollection.kitsu, statusCode: 200 })
     })
 
     it('fetches a single resource', async () => {
@@ -67,7 +68,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet(`anime/${getSingle.jsonapi.data.id}`).reply(200, getSingle.jsonapi)
       const request = await api.get('anime/1')
-      expect(request).toEqual(getSingle.kitsu)
+      expect(request).toEqual({ ...getSingle.kitsu, statusCode: 200 })
     })
 
     it('fetches a relationship collection of resources', async () => {
@@ -75,7 +76,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('authors/1/anime').reply(200, getCollection.jsonapi)
       const request = await api.get('author/1/anime')
-      expect(request).toEqual(getCollection.kitsu)
+      expect(request).toEqual({ ...getCollection.kitsu, statusCode: 200 })
     })
 
     it('fetches a relationshop single resource', async () => {
@@ -83,7 +84,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('comments/1/anime').reply(200, getSingle.jsonapi)
       const request = await api.get('comment/1/anime')
-      expect(request).toEqual(getSingle.kitsu)
+      expect(request).toEqual({ ...getSingle.kitsu, statusCode: 200 })
     })
 
     it('fetches a collection of resources with includes', async () => {
@@ -91,7 +92,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime').reply(200, getCollectionWithIncludes.jsonapi)
       const request = await api.get('anime')
-      expect(request).toEqual(getCollectionWithIncludes.kitsu)
+      expect(request).toEqual({ ...getCollectionWithIncludes.kitsu, statusCode: 200 })
     })
 
     it('fetches a single resource with includes', async () => {
@@ -99,7 +100,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet(`anime/${getSingleWithIncludes.jsonapi.data.id}`, { include: 'author,comments' }).reply(200, getSingleWithIncludes.jsonapi)
       const request = await api.get('anime/1', { params: { include: 'author,comments' } })
-      expect(request).toEqual(getSingleWithIncludes.kitsu)
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
     })
 
     it('fetches a single resource with nested includes', async () => {
@@ -107,7 +108,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime/1').reply(200, getSingleWithNestedIncludes.jsonapi)
       const request = await api.get('anime/1')
-      expect(request).toEqual(getSingleWithNestedIncludes.kitsu)
+      expect(request).toEqual({ ...getSingleWithNestedIncludes.kitsu, statusCode: 200 })
     })
 
     it('fetches a single resource with a camelCase relationship include', async () => {
@@ -115,7 +116,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('anime/1', { params: { include: 'animeStaff' } }).reply(200, getSingleWithIncludes.jsonapi)
       const request = await api.get('anime/1', { params: { include: 'animeStaff' } })
-      expect(request).toEqual(getSingleWithIncludes.kitsu)
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
     })
 
     it('fetches :resource/:id/relationships/:relationship', async () => {
@@ -133,7 +134,7 @@ describe('kitsu', () => {
       const api = new Kitsu()
       mock.onGet('media-relationships/1/relationships/destination').reply(200, response)
       const request = await api.get('mediaRelationships/1/relationships/destination')
-      expect(request).toEqual(response)
+      expect(request).toEqual({ ...response, statusCode: 200 })
     })
 
     it('fetches :resource/:relationship/:subRelationship', async () => {
@@ -147,7 +148,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ pluralize: false })
       mock.onGet('profile/user-accounts/me').reply(200, response)
       const request = await api.get('profile/userAccounts/me')
-      expect(request).toEqual(response)
+      expect(request).toEqual({ ...response, statusCode: 200 })
     })
 
     it('returns a JSON:API error object for invalid queries', async () => {
@@ -271,7 +272,8 @@ describe('kitsu', () => {
               }
             }
           }
-        ]
+        ],
+        statusCode: 200
       })
     })
   })

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -233,13 +233,13 @@ export default class Kitsu {
       // :resource/:id/:relationship/:subRelationship
       if (subRelationship) url += `/${this.resCase(subRelationship)}`
 
-      const { data, headers: responseHeaders } = await this.axios.get(url, {
+      const { data, headers: responseHeaders, status: statusCode } = await this.axios.get(url, {
         headers,
         params,
         ...config.axiosOptions
       })
 
-      return responseHeaders ? { ...deserialise(data), ...{ headers: responseHeaders } } : deserialise(data)
+      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -292,7 +292,7 @@ export default class Kitsu {
         pluralTypes: this.plural
       })
       const fullURL = body?.id ? `${url}/${body.id}` : url
-      const { data, headers: responseHeaders } = await this.axios.patch(
+      const { data, headers: responseHeaders, status: statusCode } = await this.axios.patch(
         fullURL,
         serialData,
         {
@@ -302,7 +302,7 @@ export default class Kitsu {
         }
       )
 
-      return responseHeaders ? { ...deserialise(data), ...{ headers: responseHeaders } } : deserialise(data)
+      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -349,7 +349,7 @@ export default class Kitsu {
         resourceCase: this.resCase,
         pluralModel: this.plural
       })
-      const { data, headers: responseHeaders } = await this.axios.post(
+      const { data, headers: responseHeaders, status: statusCode } = await this.axios.post(
         url,
         serialise(resourceModel, body, 'POST', {
           camelCaseTypes: this.camel,
@@ -362,7 +362,7 @@ export default class Kitsu {
         }
       )
 
-      return responseHeaders ? { ...deserialise(data), ...{ headers: responseHeaders } } : deserialise(data)
+      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -405,7 +405,7 @@ export default class Kitsu {
         payload = { id }
       }
 
-      const { data, headers: responseHeaders } = await this.axios.delete(path, {
+      const { data, headers: responseHeaders, status: statusCode } = await this.axios.delete(path, {
         data: serialise(resourceModel, payload, 'DELETE', {
           camelCaseTypes: this.camel,
           pluralTypes: this.plural
@@ -415,7 +415,7 @@ export default class Kitsu {
         ...config.axiosOptions
       })
 
-      return responseHeaders ? { ...deserialise(data), ...{ headers: responseHeaders } } : deserialise(data)
+      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -510,7 +510,7 @@ export default class Kitsu {
   async request ({ body, method, params, type, url, headers, axiosOptions }) {
     try {
       method = method?.toUpperCase() || 'GET'
-      const { data, headers: responseHeaders } = await this.axios.request({
+      const { data, headers: responseHeaders, status: statusCode } = await this.axios.request({
         method,
         url,
         data: [ 'GET', 'DELETE' ].includes(method)
@@ -524,7 +524,7 @@ export default class Kitsu {
         ...axiosOptions
       })
 
-      return responseHeaders ? { ...deserialise(data), ...{ headers: responseHeaders } } : deserialise(data)
+      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -233,13 +233,13 @@ export default class Kitsu {
       // :resource/:id/:relationship/:subRelationship
       if (subRelationship) url += `/${this.resCase(subRelationship)}`
 
-      const { data, headers: responseHeaders, status: statusCode } = await this.axios.get(url, {
+      const { data, headers: responseHeaders, status } = await this.axios.get(url, {
         headers,
         params,
         ...config.axiosOptions
       })
 
-      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
+      return { ...deserialise(data), status, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -292,7 +292,7 @@ export default class Kitsu {
         pluralTypes: this.plural
       })
       const fullURL = body?.id ? `${url}/${body.id}` : url
-      const { data, headers: responseHeaders, status: statusCode } = await this.axios.patch(
+      const { data, headers: responseHeaders, status } = await this.axios.patch(
         fullURL,
         serialData,
         {
@@ -302,7 +302,7 @@ export default class Kitsu {
         }
       )
 
-      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
+      return { ...deserialise(data), status, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -349,7 +349,7 @@ export default class Kitsu {
         resourceCase: this.resCase,
         pluralModel: this.plural
       })
-      const { data, headers: responseHeaders, status: statusCode } = await this.axios.post(
+      const { data, headers: responseHeaders, status } = await this.axios.post(
         url,
         serialise(resourceModel, body, 'POST', {
           camelCaseTypes: this.camel,
@@ -362,7 +362,7 @@ export default class Kitsu {
         }
       )
 
-      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
+      return { ...deserialise(data), status, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -405,7 +405,7 @@ export default class Kitsu {
         payload = { id }
       }
 
-      const { data, headers: responseHeaders, status: statusCode } = await this.axios.delete(path, {
+      const { data, headers: responseHeaders, status } = await this.axios.delete(path, {
         data: serialise(resourceModel, payload, 'DELETE', {
           camelCaseTypes: this.camel,
           pluralTypes: this.plural
@@ -415,7 +415,7 @@ export default class Kitsu {
         ...config.axiosOptions
       })
 
-      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
+      return { ...deserialise(data), status, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }
@@ -510,7 +510,7 @@ export default class Kitsu {
   async request ({ body, method, params, type, url, headers, axiosOptions }) {
     try {
       method = method?.toUpperCase() || 'GET'
-      const { data, headers: responseHeaders, status: statusCode } = await this.axios.request({
+      const { data, headers: responseHeaders, status } = await this.axios.request({
         method,
         url,
         data: [ 'GET', 'DELETE' ].includes(method)
@@ -524,7 +524,7 @@ export default class Kitsu {
         ...axiosOptions
       })
 
-      return { ...deserialise(data), statusCode, ...(responseHeaders ? { headers: responseHeaders } : {}) }
+      return { ...deserialise(data), status, ...(responseHeaders ? { headers: responseHeaders } : {}) }
     } catch (E) {
       throw error(E)
     }

--- a/packages/kitsu/src/patch.spec.js
+++ b/packages/kitsu/src/patch.spec.js
@@ -40,7 +40,7 @@ describe('kitsu', () => {
         headers: {
           Accept: 'application/vnd.api+json'
         },
-        statusCode: 200
+        status: 200
       })
     })
 
@@ -59,7 +59,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.patch('post', { id: '1', content: 'Hello World' })).toEqual({ statusCode: 200 })
+      await expect(await api.patch('post', { id: '1', content: 'Hello World' })).toEqual({ status: 200 })
     })
 
     it('sends bulk data in request', async () => {
@@ -89,7 +89,7 @@ describe('kitsu', () => {
       await expect(await api.patch('post', [
         { id: '1', content: 'Hello World' },
         { id: '2', content: 'Hey World' }
-      ])).toEqual({ statusCode: 200 })
+      ])).toEqual({ status: 200 })
     })
 
     it('throws an error if missing a JSON object body', async () => {
@@ -117,7 +117,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ headers: { Authorization: true } })
       mock.onPatch(`posts/${patchSingle.jsonapi.data.id}`).reply(200, patchSingle.jsonapi)
       const request = await api.patch('posts', patchSingle.kitsu)
-      expect(request).toEqual({ data: patchSingle.kitsu, statusCode: 200 })
+      expect(request).toEqual({ data: patchSingle.kitsu, status: 200 })
     })
 
     it('handes nested routes', async () => {
@@ -125,7 +125,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ headers: { Authorization: true } })
       mock.onPatch(`something/1/relationships/posts/${patchSingle.jsonapi.data.id}`).reply(200, patchSingle.jsonapi)
       const request = await api.patch('something/1/relationships/posts', patchSingle.kitsu)
-      expect(request).toEqual({ data: patchSingle.kitsu, statusCode: 200 })
+      expect(request).toEqual({ data: patchSingle.kitsu, status: 200 })
     })
   })
 })

--- a/packages/kitsu/src/patch.spec.js
+++ b/packages/kitsu/src/patch.spec.js
@@ -39,7 +39,8 @@ describe('kitsu', () => {
       await expect(await api.patch('anime', { id: '1', type: 'anime' }, { headers: { extra: true } })).toEqual({
         headers: {
           Accept: 'application/vnd.api+json'
-        }
+        },
+        statusCode: 200
       })
     })
 
@@ -58,7 +59,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.patch('post', { id: '1', content: 'Hello World' })).toBeUndefined()
+      await expect(await api.patch('post', { id: '1', content: 'Hello World' })).toEqual({ statusCode: 200 })
     })
 
     it('sends bulk data in request', async () => {
@@ -88,7 +89,7 @@ describe('kitsu', () => {
       await expect(await api.patch('post', [
         { id: '1', content: 'Hello World' },
         { id: '2', content: 'Hey World' }
-      ])).toBeUndefined()
+      ])).toEqual({ statusCode: 200 })
     })
 
     it('throws an error if missing a JSON object body', async () => {
@@ -116,7 +117,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ headers: { Authorization: true } })
       mock.onPatch(`posts/${patchSingle.jsonapi.data.id}`).reply(200, patchSingle.jsonapi)
       const request = await api.patch('posts', patchSingle.kitsu)
-      expect(request).toEqual({ data: patchSingle.kitsu })
+      expect(request).toEqual({ data: patchSingle.kitsu, statusCode: 200 })
     })
 
     it('handes nested routes', async () => {
@@ -124,7 +125,7 @@ describe('kitsu', () => {
       const api = new Kitsu({ headers: { Authorization: true } })
       mock.onPatch(`something/1/relationships/posts/${patchSingle.jsonapi.data.id}`).reply(200, patchSingle.jsonapi)
       const request = await api.patch('something/1/relationships/posts', patchSingle.kitsu)
-      expect(request).toEqual({ data: patchSingle.kitsu })
+      expect(request).toEqual({ data: patchSingle.kitsu, statusCode: 200 })
     })
   })
 })

--- a/packages/kitsu/src/post.spec.js
+++ b/packages/kitsu/src/post.spec.js
@@ -35,7 +35,8 @@ describe('kitsu', () => {
       await expect(await api.post('anime', { id: '1', type: 'anime' }, { headers: { extra: true } })).toEqual({
         headers: {
           Accept: 'application/vnd.api+json'
-        }
+        },
+        statusCode: 200
       })
     })
 
@@ -53,7 +54,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', { type: 'anime', name: 'Name' })).toBeUndefined()
+      await expect(await api.post('anime', { type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
     })
 
     it('handles nested routes', async () => {
@@ -70,7 +71,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('something/1/relationships/anime', { type: 'anime', name: 'Name' })).toBeUndefined()
+      await expect(await api.post('something/1/relationships/anime', { type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
     })
 
     it('sends data in request with client-generated ID', async () => {
@@ -88,7 +89,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', { id: 123456789, type: 'anime', name: 'Name' })).toBeUndefined()
+      await expect(await api.post('anime', { id: 123456789, type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
     })
 
     it('throws an error if missing a valid JSON object body', async () => {
@@ -116,8 +117,8 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime')).toBeUndefined()
-      await expect(await api.post('anime', {})).toBeUndefined()
+      await expect(await api.post('anime')).toEqual({ statusCode: 200 })
+      await expect(await api.post('anime', {})).toEqual({ statusCode: 200 })
     })
 
     it('sends data in request if given empty JSON object in array body', async () => {
@@ -129,7 +130,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', [ {} ])).toBeUndefined()
+      await expect(await api.post('anime', [ {} ])).toEqual({ statusCode: 200 })
     })
   })
 })

--- a/packages/kitsu/src/post.spec.js
+++ b/packages/kitsu/src/post.spec.js
@@ -36,7 +36,7 @@ describe('kitsu', () => {
         headers: {
           Accept: 'application/vnd.api+json'
         },
-        statusCode: 200
+        status: 200
       })
     })
 
@@ -54,7 +54,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', { type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
+      await expect(await api.post('anime', { type: 'anime', name: 'Name' })).toEqual({ status: 200 })
     })
 
     it('handles nested routes', async () => {
@@ -71,7 +71,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('something/1/relationships/anime', { type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
+      await expect(await api.post('something/1/relationships/anime', { type: 'anime', name: 'Name' })).toEqual({ status: 200 })
     })
 
     it('sends data in request with client-generated ID', async () => {
@@ -89,7 +89,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', { id: 123456789, type: 'anime', name: 'Name' })).toEqual({ statusCode: 200 })
+      await expect(await api.post('anime', { id: 123456789, type: 'anime', name: 'Name' })).toEqual({ status: 200 })
     })
 
     it('throws an error if missing a valid JSON object body', async () => {
@@ -117,8 +117,8 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime')).toEqual({ statusCode: 200 })
-      await expect(await api.post('anime', {})).toEqual({ statusCode: 200 })
+      await expect(await api.post('anime')).toEqual({ status: 200 })
+      await expect(await api.post('anime', {})).toEqual({ status: 200 })
     })
 
     it('sends data in request if given empty JSON object in array body', async () => {
@@ -130,7 +130,7 @@ describe('kitsu', () => {
         })
         return [ 200 ]
       })
-      await expect(await api.post('anime', [ {} ])).toEqual({ statusCode: 200 })
+      await expect(await api.post('anime', [ {} ])).toEqual({ status: 200 })
     })
   })
 })

--- a/packages/kitsu/src/request.spec.js
+++ b/packages/kitsu/src/request.spec.js
@@ -54,7 +54,7 @@ describe('kitsu', () => {
         url: 'users',
         model: 'users',
         headers: { extra: true }
-      })).toEqual({ data: [], headers: { Accept: 'application/vnd.api+json' }, statusCode: 200 })
+      })).toEqual({ data: [], headers: { Accept: 'application/vnd.api+json' }, status: 200 })
     })
 
     it('sends parameters', async () => {
@@ -66,7 +66,7 @@ describe('kitsu', () => {
         url: 'anime/1',
         params: { include: 'author,comments' }
       })
-      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, status: 200 })
     })
 
     it('defaults to a GET request', async () => {
@@ -76,7 +76,7 @@ describe('kitsu', () => {
       const request = await api.request({
         url: 'anime/1'
       })
-      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
+      expect(request).toEqual({ ...genericRequest, status: 200 })
     })
 
     it('handles method case differences', async () => {
@@ -87,7 +87,7 @@ describe('kitsu', () => {
         method: 'gEt',
         url: 'anime/1'
       })
-      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
+      expect(request).toEqual({ ...genericRequest, status: 200 })
     })
 
     it('makes PATCH requests', async () => {
@@ -100,7 +100,7 @@ describe('kitsu', () => {
         type: 'anime',
         body: genericResponse.data
       })
-      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
+      expect(request).toEqual({ ...genericRequest, status: 200 })
     })
 
     it('makes PATCH requests (array)', async () => {
@@ -126,7 +126,7 @@ describe('kitsu', () => {
           genericRequest.data,
           genericRequest.data
         ],
-        statusCode: 200
+        status: 200
       })
     })
 
@@ -140,7 +140,7 @@ describe('kitsu', () => {
         type: 'anime',
         body: genericResponse.data
       })
-      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
+      expect(request).toEqual({ ...genericRequest, status: 200 })
     })
 
     it('makes DELETE requests', async () => {
@@ -152,7 +152,7 @@ describe('kitsu', () => {
         type: 'anime',
         url: 'anime/1'
       })
-      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
+      expect(request).toEqual({ ...genericRequest, status: 200 })
     })
 
     it('throws an error if body is missing', async () => {
@@ -175,7 +175,7 @@ describe('kitsu', () => {
         url: 'anime/1',
         params: { include: 'animeStaff' }
       })
-      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, status: 200 })
     })
   })
 })

--- a/packages/kitsu/src/request.spec.js
+++ b/packages/kitsu/src/request.spec.js
@@ -54,7 +54,7 @@ describe('kitsu', () => {
         url: 'users',
         model: 'users',
         headers: { extra: true }
-      })).toEqual({ data: [], headers: { Accept: 'application/vnd.api+json' } })
+      })).toEqual({ data: [], headers: { Accept: 'application/vnd.api+json' }, statusCode: 200 })
     })
 
     it('sends parameters', async () => {
@@ -66,7 +66,7 @@ describe('kitsu', () => {
         url: 'anime/1',
         params: { include: 'author,comments' }
       })
-      expect(request).toEqual(getSingleWithIncludes.kitsu)
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
     })
 
     it('defaults to a GET request', async () => {
@@ -76,7 +76,7 @@ describe('kitsu', () => {
       const request = await api.request({
         url: 'anime/1'
       })
-      expect(request).toEqual(genericRequest)
+      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
     })
 
     it('handles method case differences', async () => {
@@ -87,7 +87,7 @@ describe('kitsu', () => {
         method: 'gEt',
         url: 'anime/1'
       })
-      expect(request).toEqual(genericRequest)
+      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
     })
 
     it('makes PATCH requests', async () => {
@@ -100,7 +100,7 @@ describe('kitsu', () => {
         type: 'anime',
         body: genericResponse.data
       })
-      expect(request).toEqual(genericRequest)
+      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
     })
 
     it('makes PATCH requests (array)', async () => {
@@ -125,7 +125,8 @@ describe('kitsu', () => {
         data: [
           genericRequest.data,
           genericRequest.data
-        ]
+        ],
+        statusCode: 200
       })
     })
 
@@ -139,7 +140,7 @@ describe('kitsu', () => {
         type: 'anime',
         body: genericResponse.data
       })
-      expect(request).toEqual(genericRequest)
+      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
     })
 
     it('makes DELETE requests', async () => {
@@ -151,7 +152,7 @@ describe('kitsu', () => {
         type: 'anime',
         url: 'anime/1'
       })
-      expect(request).toEqual(genericRequest)
+      expect(request).toEqual({ ...genericRequest, statusCode: 200 })
     })
 
     it('throws an error if body is missing', async () => {
@@ -174,7 +175,7 @@ describe('kitsu', () => {
         url: 'anime/1',
         params: { include: 'animeStaff' }
       })
-      expect(request).toEqual(getSingleWithIncludes.kitsu)
+      expect(request).toEqual({ ...getSingleWithIncludes.kitsu, statusCode: 200 })
     })
   })
 })


### PR DESCRIPTION
Thanks for Kitsu! It's awesome :-)

We wanted to know whether the HTTP status code was a 206 to know if we'd received a partial response - and were wondering if you'd be willing to land this tweak to add it to the result :-)

_Also, on looking a bit closer, I noticed that this isn't in the other methods in the same file - would be willing to add it more places if that's helpful_ :slightly_smiling_face: 