### PR TITLE
chore: update the default baseURL to the new kitsu domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href=https://github.com/sponsors/wopian><img alt=sponsor src='https://flat.badgen.net/badge/sponsor/%E2%9D%A4/pink?icon=github'></a>
 </p>
 
-<p align=center>A simple, lightweight & framework agnostic <a href=http://jsonapi.org>JSON:API</a> client for <a href=https://kitsu.io>Kitsu.io</a> & other APIs</p>
+<p align=center>A simple, lightweight & framework agnostic <a href=http://jsonapi.org>JSON:API</a> client for <a href=https://kitsu.app>kitsu.app</a> & other APIs</p>
 
 #
 

--- a/packages/kitsu-core/src/deserialise/index.spec.js
+++ b/packages/kitsu-core/src/deserialise/index.spec.js
@@ -248,14 +248,14 @@ describe('kitsu-core', () => {
             relationships: {
               follower: {
                 links: {
-                  self: 'https://kitsu.io/follows/1/relationships/follower',
-                  related: 'https://kitsu.io/follows/1/follower'
+                  self: 'https://kitsu.app/follows/1/relationships/follower',
+                  related: 'https://kitsu.app/follows/1/follower'
                 }
               },
               followed: {
                 links: {
-                  self: 'https://kitsu.io/follows/1/relationships/followed',
-                  related: 'https://kitsu.io/follows/1/followed'
+                  self: 'https://kitsu.app/follows/1/relationships/followed',
+                  related: 'https://kitsu.app/follows/1/followed'
                 }
               }
             }
@@ -269,14 +269,14 @@ describe('kitsu-core', () => {
             relationships: {
               follower: {
                 links: {
-                  self: 'https://kitsu.io/follows/2/relationships/follower',
-                  related: 'https://kitsu.io/follows/2/follower'
+                  self: 'https://kitsu.app/follows/2/relationships/follower',
+                  related: 'https://kitsu.app/follows/2/follower'
                 }
               },
               followed: {
                 links: {
-                  self: 'https://kitsu.io/follows/2/relationships/followed',
-                  related: 'https://kitsu.io/follows/2/followed'
+                  self: 'https://kitsu.app/follows/2/relationships/followed',
+                  related: 'https://kitsu.app/follows/2/followed'
                 }
               }
             }
@@ -302,14 +302,14 @@ describe('kitsu-core', () => {
                 },
                 follower: {
                   links: {
-                    self: 'https://kitsu.io/follows/1/relationships/follower',
-                    related: 'https://kitsu.io/follows/1/follower'
+                    self: 'https://kitsu.app/follows/1/relationships/follower',
+                    related: 'https://kitsu.app/follows/1/follower'
                   }
                 },
                 followed: {
                   links: {
-                    self: 'https://kitsu.io/follows/1/relationships/followed',
-                    related: 'https://kitsu.io/follows/1/followed'
+                    self: 'https://kitsu.app/follows/1/relationships/followed',
+                    related: 'https://kitsu.app/follows/1/followed'
                   }
                 }
               },
@@ -321,14 +321,14 @@ describe('kitsu-core', () => {
                 },
                 follower: {
                   links: {
-                    self: 'https://kitsu.io/follows/2/relationships/follower',
-                    related: 'https://kitsu.io/follows/2/follower'
+                    self: 'https://kitsu.app/follows/2/relationships/follower',
+                    related: 'https://kitsu.app/follows/2/follower'
                   }
                 },
                 followed: {
                   links: {
-                    self: 'https://kitsu.io/follows/2/relationships/followed',
-                    related: 'https://kitsu.io/follows/2/followed'
+                    self: 'https://kitsu.app/follows/2/relationships/followed',
+                    related: 'https://kitsu.app/follows/2/followed'
                   }
                 }
               }
@@ -370,8 +370,8 @@ describe('kitsu-core', () => {
             relationships: {
               primaryMedia: {
                 links: {
-                  self: 'https://kitsu.io/characters/1/relationships/primary-media',
-                  related: 'https://kitsu.io/characters/1/primary-media'
+                  self: 'https://kitsu.app/characters/1/relationships/primary-media',
+                  related: 'https://kitsu.app/characters/1/primary-media'
                 }
               }
             }
@@ -396,8 +396,8 @@ describe('kitsu-core', () => {
               },
               primaryMedia: {
                 links: {
-                  self: 'https://kitsu.io/characters/1/relationships/primary-media',
-                  related: 'https://kitsu.io/characters/1/primary-media'
+                  self: 'https://kitsu.app/characters/1/relationships/primary-media',
+                  related: 'https://kitsu.app/characters/1/primary-media'
                 }
               }
             }
@@ -1036,8 +1036,8 @@ describe('kitsu-core', () => {
             relationships: {
               follower: {
                 links: {
-                  self: 'https://kitsu.io/follows/1/relationships/follower',
-                  related: 'https://kitsu.io/follows/1/follower'
+                  self: 'https://kitsu.app/follows/1/relationships/follower',
+                  related: 'https://kitsu.app/follows/1/follower'
                 }
               }
             }
@@ -1067,8 +1067,8 @@ describe('kitsu-core', () => {
                 },
                 follower: {
                   links: {
-                    self: 'https://kitsu.io/follows/1/relationships/follower',
-                    related: 'https://kitsu.io/follows/1/follower'
+                    self: 'https://kitsu.app/follows/1/relationships/follower',
+                    related: 'https://kitsu.app/follows/1/follower'
                   }
                 }
               }

--- a/packages/kitsu/MIGRATING.md
+++ b/packages/kitsu/MIGRATING.md
@@ -235,7 +235,7 @@ data: {
   id: '1',
   type: 'libraryEntries'
   links: {
-    self: 'https://kitsu.io/api/edge/library-entries/1'
+    self: 'https://kitsu.app/api/edge/library-entries/1'
   },
   attributes: {
     ratingTwenty: 10
@@ -243,8 +243,8 @@ data: {
   relationships: {
     user: {
       links: {
-        self: 'https://kitsu.io/api/edge/library-entries/1/relationships/user',
-        related: 'https://kitsu.io/api/edge/library-entries/1/user'
+        self: 'https://kitsu.app/api/edge/library-entries/1/relationships/user',
+        related: 'https://kitsu.app/api/edge/library-entries/1/user'
       },
       data: {
         id: '2',
@@ -258,7 +258,7 @@ included: [
     id: '2',
     type: 'users',
     links: {
-      self: 'https://kitsu.io/api/edge/users/2'
+      self: 'https://kitsu.app/api/edge/users/2'
     },
     attributes: {
       name: 'Example'
@@ -291,19 +291,19 @@ data: {
   id: '1',
   type: 'libraryEntries',
   links: {
-    self: 'https://kitsu.io/api/edge/library-entries/1'
+    self: 'https://kitsu.app/api/edge/library-entries/1'
   },
   ratingTwenty: 10,
   user: {
     links: {
-      self: 'https://kitsu.io/api/edge/library-entries/1/relationships/user',
-      related: 'https://kitsu.io/api/edge/library-entries/1/user'
+      self: 'https://kitsu.app/api/edge/library-entries/1/relationships/user',
+      related: 'https://kitsu.app/api/edge/library-entries/1/user'
     }
     data: {
       id: '2',
       type: 'users',
       links: {
-        self: 'https://kitsu.io/api/edge/users/2'
+        self: 'https://kitsu.app/api/edge/users/2'
       },
       name: 'Example'
     }

--- a/packages/kitsu/README.md
+++ b/packages/kitsu/README.md
@@ -116,7 +116,7 @@ const Kitsu = require("kitsu"); // CommonJS & Browserify
 ## Quick Start
 
 ```javascript
-// Kitsu.io's API
+// kitsu.app's API
 const api = new Kitsu()
 
 // Other JSON:API servers
@@ -173,7 +173,7 @@ api.get('users', {
 
 [More Examples]
 
-If you're working with [Kitsu.io]'s API, their [API docs][kitsu.io api docs] lists all available resources with their attributes & relationships
+If you're working with [kitsu.app]'s API, their [API docs][kitsu.app api docs] lists all available resources with their attributes & relationships
 
 ## Contributing
 
@@ -187,7 +187,7 @@ See [CHANGELOG]
 
 All code released under [MIT]
 
-[kitsu.io]: https://kitsu.io
+[kitsu.app]: https://kitsu.app
 
 [json:api]: http://jsonapi.org
 
@@ -195,7 +195,7 @@ All code released under [MIT]
 
 [more examples]: https://github.com/wopian/kitsu/tree/master/packages/kitsu/example
 
-[kitsu.io api docs]: https://kitsu.docs.apiary.io
+[kitsu.app api docs]: https://kitsu.docs.apiary.io
 
 [migration guide]: https://github.com/wopian/kitsu/blob/master/packages/kitsu/MIGRATING.md
 
@@ -249,7 +249,7 @@ Creates a new `kitsu` instance
 
 *   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
 
-    *   `options.baseURL` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Set the API endpoint (optional, default `https://kitsu.io/api/edge`)
+    *   `options.baseURL` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Set the API endpoint (optional, default `https://kitsu.app/api/edge`)
     *   `options.headers` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Additional headers to send with the requests
     *   `options.query` **(`"traditional"` | `"modern"` | [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function))** Query serializer function to use. This will impact the way keys are serialized when passing arrays as query parameters. 'modern' is recommended for new projects. (optional, default `traditional`)
     *   `options.camelCaseTypes` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If enabled, `type` will be converted to camelCase from kebab-casae or snake\_case (optional, default `true`)
@@ -260,7 +260,7 @@ Creates a new `kitsu` instance
 
 #### Examples
 
-Using with Kitsu.io's API
+Using with kitsu.app's API
 
 ```javascript
 const api = new Kitsu()
@@ -399,12 +399,12 @@ Fetch resources (alias `fetch`)
         *   `config.params.sort` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Sort dataset by one or more comma separated attributes (prepend `-` for descending order) - [JSON:API Sorting](http://jsonapi.org/format/#fetching-sorting)
         *   `config.params.page` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** [JSON:API Pagination](http://jsonapi.org/format/#fetching-pagination). All pagination strategies are supported, even if they are not listed below.
 
-            *   `config.params.page.limit` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Number of resources to return in request (Offset-based) - **Note:** For Kitsu.io, max is `20` except on `libraryEntries` which has a max of `500`
+            *   `config.params.page.limit` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Number of resources to return in request (Offset-based) - **Note:** For kitsu.app, max is `20` except on `libraryEntries` which has a max of `500`
             *   `config.params.page.offset` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Number of resources to offset the dataset by (Offset-based)
-            *   `config.params.page.number` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Page of resources to return in request (Page-based) - **Note:** Not supported on Kitsu.io
-            *   `config.params.page.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on Kitsu.io
-            *   `config.params.page.before` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Get the previous page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
-            *   `config.params.page.after` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Get the next page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
+            *   `config.params.page.number` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Page of resources to return in request (Page-based) - **Note:** Not supported on kitsu.app
+            *   `config.params.page.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on kitsu.app
+            *   `config.params.page.before` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Get the previous page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
+            *   `config.params.page.after` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Get the next page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
     *   `config.axiosOptions` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Additional options for the axios instance (see [axios/axios#request-config](https://github.com/axios/axios#request-config) for details)
 
 ##### Examples
@@ -461,7 +461,7 @@ Getting a resource's relationship data only
 api.get('anime/2/categories')
 ```
 
-Getting a resource with nested JSON:API filters (not supported by Kitsu.io's API)
+Getting a resource with nested JSON:API filters (not supported by kitsu.app's API)
 
 ```javascript
 // resource?filter[x][y]=value

--- a/packages/kitsu/example/auth.js
+++ b/packages/kitsu/example/auth.js
@@ -10,7 +10,7 @@ const app = async () => {
   const { owner } = new OAuth2({
     clientId: '',
     clientSecret: '',
-    accessTokenUri: 'https://kitsu.io/api/oauth/token'
+    accessTokenUri: 'https://kitsu.app/api/oauth/token'
   })
 
   const { accessToken } = await owner.getToken('username', 'password')

--- a/packages/kitsu/package.json
+++ b/packages/kitsu/package.json
@@ -26,7 +26,7 @@
   },
   "keywords": [
     "kitsu",
-    "kitsu.io",
+    "kitsu.app",
     "anime",
     "manga",
     "drama",

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -6,7 +6,7 @@ import pluralise from 'pluralize'
  * Creates a new `kitsu` instance
  *
  * @param {Object} [options] Options
- * @param {string} [options.baseURL=https://kitsu.io/api/edge] Set the API endpoint
+ * @param {string} [options.baseURL=https://kitsu.app/api/edge] Set the API endpoint
  * @param {Object} [options.headers] Additional headers to send with the requests
  * @param {'traditional'|'modern'|Function} [options.query=traditional] Query serializer function to use. This will impact the way keys are serialized when passing arrays as query parameters. 'modern' is recommended for new projects.
  * @param {boolean} [options.camelCaseTypes=true] If enabled, `type` will be converted to camelCase from kebab-casae or snake_case
@@ -14,7 +14,7 @@ import pluralise from 'pluralize'
  * @param {boolean} [options.pluralize=true] If enabled, `/user` will become `/users` in the URL request and `type` will be pluralized in POST, PATCH and DELETE requests
  * @param {number} [options.timeout=30000] Set the request timeout in milliseconds
  * @param {Object} [options.axiosOptions] Additional options for the axios instance (see [axios/axios#request-config](https://github.com/axios/axios#request-config) for details)
- * @example <caption>Using with Kitsu.io's API</caption>
+ * @example <caption>Using with kitsu.app's API</caption>
  * const api = new Kitsu()
  * @example <caption>Using another API server</caption>
  * const api = new Kitsu({
@@ -133,12 +133,12 @@ export default class Kitsu {
    * @param {string} [config.params.include] Include relationship data - [JSON:API Includes](http://jsonapi.org/format/#fetching-includes)
    * @param {string} [config.params.sort] Sort dataset by one or more comma separated attributes (prepend `-` for descending order) - [JSON:API Sorting](http://jsonapi.org/format/#fetching-sorting)
    * @param {Object} [config.params.page] [JSON:API Pagination](http://jsonapi.org/format/#fetching-pagination). All pagination strategies are supported, even if they are not listed below.
-   * @param {number} [config.params.page.limit] Number of resources to return in request (Offset-based) - **Note:** For Kitsu.io, max is `20` except on `libraryEntries` which has a max of `500`
+   * @param {number} [config.params.page.limit] Number of resources to return in request (Offset-based) - **Note:** For kitsu.app, max is `20` except on `libraryEntries` which has a max of `500`
    * @param {number} [config.params.page.offset] Number of resources to offset the dataset by (Offset-based)
-   * @param {number} [config.params.page.number] Page of resources to return in request (Page-based) - **Note:** Not supported on Kitsu.io
-   * @param {number} [config.params.page.size] Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on Kitsu.io
-   * @param {string} [config.params.page.before] Get the previous page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
-   * @param {string} [config.params.page.after] Get the next page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
+   * @param {number} [config.params.page.number] Page of resources to return in request (Page-based) - **Note:** Not supported on kitsu.app
+   * @param {number} [config.params.page.size] Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on kitsu.app
+   * @param {string} [config.params.page.before] Get the previous page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
+   * @param {string} [config.params.page.after] Get the next page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
    * @param {Object} [config.axiosOptions] Additional options for the axios instance (see [axios/axios#request-config](https://github.com/axios/axios#request-config) for details)
    * @returns {Object} JSON-parsed response
    * @example <caption>Getting a resource with JSON:API parameters</caption>
@@ -173,7 +173,7 @@ export default class Kitsu {
    * })
    * @example <caption>Getting a resource's relationship data only</caption>
    * api.get('anime/2/categories')
-   * @example <caption>Getting a resource with nested JSON:API filters (not supported by Kitsu.io's API)</caption>
+   * @example <caption>Getting a resource with nested JSON:API filters (not supported by kitsu.app's API)</caption>
    * // resource?filter[x][y]=value
    * api.get('resource', {
    *   params: {

--- a/packages/kitsu/src/index.js
+++ b/packages/kitsu/src/index.js
@@ -74,7 +74,7 @@ export default class Kitsu {
 
     this.axios = axios.create({
       ...{
-        baseURL: options.baseURL || 'https://kitsu.io/api/edge',
+        baseURL: options.baseURL || 'https://kitsu.app/api/edge',
         timeout: options.timeout || 30000
       },
       paramsSerializer: { serialize: /* istanbul ignore next */ p => this.query(p) },

--- a/packages/kitsu/src/index.spec.js
+++ b/packages/kitsu/src/index.spec.js
@@ -121,10 +121,10 @@ describe('kitsu', () => {
       expect(api.plural('apple')).toBe('apple')
     })
 
-    it('uses Kitsu.io\'s API by default', () => {
+    it('uses kitsu.app\'s API by default', () => {
       expect.assertions(1)
       const api = new Kitsu()
-      expect(api.axios.defaults.baseURL).toBe('https://kitsu.io/api/edge')
+      expect(api.axios.defaults.baseURL).toBe('https://kitsu.app/api/edge')
     })
 
     it('uses the API provided in constructor', () => {

--- a/packages/kitsu/types/index.d.ts
+++ b/packages/kitsu/types/index.d.ts
@@ -2,7 +2,7 @@
  * Creates a new `kitsu` instance
  *
  * @param {Object} [options] Options
- * @param {string} [options.baseURL=https://kitsu.io/api/edge] Set the API endpoint
+ * @param {string} [options.baseURL=https://kitsu.app/api/edge] Set the API endpoint
  * @param {Object} [options.headers] Additional headers to send with the requests
  * @param {'traditional'|'modern'|Function} [options.query=traditional] Query serializer function to use. This will impact the way keys are serialized when passing arrays as query parameters. 'modern' is recommended for new projects.
  * @param {boolean} [options.camelCaseTypes=true] If enabled, `type` will be converted to camelCase from kebab-casae or snake_case
@@ -10,7 +10,7 @@
  * @param {boolean} [options.pluralize=true] If enabled, `/user` will become `/users` in the URL request and `type` will be pluralized in POST, PATCH and DELETE requests
  * @param {number} [options.timeout=30000] Set the request timeout in milliseconds
  * @param {Object} [options.axiosOptions] Additional options for the axios instance (see [axios/axios#request-config](https://github.com/axios/axios#request-config) for details)
- * @example <caption>Using with Kitsu.io's API</caption>
+ * @example <caption>Using with kitsu.app's API</caption>
  * const api = new Kitsu()
  * @example <caption>Using another API server</caption>
  * const api = new Kitsu({
@@ -125,12 +125,12 @@ export default class Kitsu {
      * @param {string} [config.params.include] Include relationship data - [JSON:API Includes](http://jsonapi.org/format/#fetching-includes)
      * @param {string} [config.params.sort] Sort dataset by one or more comma separated attributes (prepend `-` for descending order) - [JSON:API Sorting](http://jsonapi.org/format/#fetching-sorting)
      * @param {Object} [config.params.page] [JSON:API Pagination](http://jsonapi.org/format/#fetching-pagination). All pagination strategies are supported, even if they are not listed below.
-     * @param {number} [config.params.page.limit] Number of resources to return in request (Offset-based) - **Note:** For Kitsu.io, max is `20` except on `libraryEntries` which has a max of `500`
+     * @param {number} [config.params.page.limit] Number of resources to return in request (Offset-based) - **Note:** For kitsu.app, max is `20` except on `libraryEntries` which has a max of `500`
      * @param {number} [config.params.page.offset] Number of resources to offset the dataset by (Offset-based)
-     * @param {number} [config.params.page.number] Page of resources to return in request (Page-based) - **Note:** Not supported on Kitsu.io
-     * @param {number} [config.params.page.size] Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on Kitsu.io
-     * @param {string} [config.params.page.before] Get the previous page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
-     * @param {string} [config.params.page.after] Get the next page of resources (Cursor-based) - **Note:** Not Supported on Kitsu.io
+     * @param {number} [config.params.page.number] Page of resources to return in request (Page-based) - **Note:** Not supported on kitsu.app
+     * @param {number} [config.params.page.size] Number of resources to return in request (Page-based and cursor-based) - **Note:** Not supported on kitsu.app
+     * @param {string} [config.params.page.before] Get the previous page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
+     * @param {string} [config.params.page.after] Get the next page of resources (Cursor-based) - **Note:** Not Supported on kitsu.app
      * @param {Object} [config.axiosOptions] Additional options for the axios instance (see [axios/axios#request-config](https://github.com/axios/axios#request-config) for details)
      * @returns {Object} JSON-parsed response
      * @example <caption>Getting a resource with JSON:API parameters</caption>
@@ -165,7 +165,7 @@ export default class Kitsu {
      * })
      * @example <caption>Getting a resource's relationship data only</caption>
      * api.get('anime/2/categories')
-     * @example <caption>Getting a resource with nested JSON:API filters (not supported by Kitsu.io's API)</caption>
+     * @example <caption>Getting a resource with nested JSON:API filters (not supported by kitsu.app's API)</caption>
      * // resource?filter[x][y]=value
      * api.get('resource', {
      *   params: {

--- a/specification/getCollection/jsonapi.js
+++ b/specification/getCollection/jsonapi.js
@@ -6,7 +6,7 @@ export default {
       id: '1',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/1'
+        self: 'https://kitsu.app/api/edge/anime/1'
       },
       attributes: {
         createdAt: '2013-02-20T16:00:13.609Z',
@@ -57,11 +57,11 @@ export default {
         status: 'finished',
         tba: '',
         posterImage: {
-          tiny: 'https://media.kitsu.io/anime/poster_images/1/tiny.jpg?1431697256',
-          small: 'https://media.kitsu.io/anime/poster_images/1/small.jpg?1431697256',
-          medium: 'https://media.kitsu.io/anime/poster_images/1/medium.jpg?1431697256',
-          large: 'https://media.kitsu.io/anime/poster_images/1/large.jpg?1431697256',
-          original: 'https://media.kitsu.io/anime/poster_images/1/original.jpg?1431697256',
+          tiny: 'https://media.kitsu.app/anime/poster_images/1/tiny.jpg?1431697256',
+          small: 'https://media.kitsu.app/anime/poster_images/1/small.jpg?1431697256',
+          medium: 'https://media.kitsu.app/anime/poster_images/1/medium.jpg?1431697256',
+          large: 'https://media.kitsu.app/anime/poster_images/1/large.jpg?1431697256',
+          original: 'https://media.kitsu.app/anime/poster_images/1/original.jpg?1431697256',
           meta: {
             dimensions: {
               tiny: {
@@ -84,10 +84,10 @@ export default {
           }
         },
         coverImage: {
-          tiny: 'https://media.kitsu.io/anime/cover_images/1/tiny.jpg?1416336000',
-          small: 'https://media.kitsu.io/anime/cover_images/1/small.jpg?1416336000',
-          large: 'https://media.kitsu.io/anime/cover_images/1/large.jpg?1416336000',
-          original: 'https://media.kitsu.io/anime/cover_images/1/original.jpg?1416336000',
+          tiny: 'https://media.kitsu.app/anime/cover_images/1/tiny.jpg?1416336000',
+          small: 'https://media.kitsu.app/anime/cover_images/1/small.jpg?1416336000',
+          large: 'https://media.kitsu.app/anime/cover_images/1/large.jpg?1416336000',
+          original: 'https://media.kitsu.app/anime/cover_images/1/original.jpg?1416336000',
           meta: {
             dimensions: {
               tiny: {
@@ -114,74 +114,74 @@ export default {
       relationships: {
         genres: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/genres',
-            related: 'https://kitsu.io/api/edge/anime/1/genres'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/genres',
+            related: 'https://kitsu.app/api/edge/anime/1/genres'
           }
         },
         categories: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/categories',
-            related: 'https://kitsu.io/api/edge/anime/1/categories'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/categories',
+            related: 'https://kitsu.app/api/edge/anime/1/categories'
           }
         },
         castings: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/castings',
-            related: 'https://kitsu.io/api/edge/anime/1/castings'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/castings',
+            related: 'https://kitsu.app/api/edge/anime/1/castings'
           }
         },
         installments: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/installments',
-            related: 'https://kitsu.io/api/edge/anime/1/installments'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/installments',
+            related: 'https://kitsu.app/api/edge/anime/1/installments'
           }
         },
         mappings: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/mappings',
-            related: 'https://kitsu.io/api/edge/anime/1/mappings'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/mappings',
+            related: 'https://kitsu.app/api/edge/anime/1/mappings'
           }
         },
         reviews: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/reviews',
-            related: 'https://kitsu.io/api/edge/anime/1/reviews'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/reviews',
+            related: 'https://kitsu.app/api/edge/anime/1/reviews'
           }
         },
         mediaRelationships: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/media-relationships',
-            related: 'https://kitsu.io/api/edge/anime/1/media-relationships'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/media-relationships',
+            related: 'https://kitsu.app/api/edge/anime/1/media-relationships'
           }
         },
         episodes: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/episodes',
-            related: 'https://kitsu.io/api/edge/anime/1/episodes'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/episodes',
+            related: 'https://kitsu.app/api/edge/anime/1/episodes'
           }
         },
         streamingLinks: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/streaming-links',
-            related: 'https://kitsu.io/api/edge/anime/1/streaming-links'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/streaming-links',
+            related: 'https://kitsu.app/api/edge/anime/1/streaming-links'
           }
         },
         animeProductions: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-productions',
-            related: 'https://kitsu.io/api/edge/anime/1/anime-productions'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-productions',
+            related: 'https://kitsu.app/api/edge/anime/1/anime-productions'
           }
         },
         animeCharacters: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-characters',
-            related: 'https://kitsu.io/api/edge/anime/1/anime-characters'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-characters',
+            related: 'https://kitsu.app/api/edge/anime/1/anime-characters'
           }
         },
         animeStaff: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-staff',
-            related: 'https://kitsu.io/api/edge/anime/1/anime-staff'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-staff',
+            related: 'https://kitsu.app/api/edge/anime/1/anime-staff'
           }
         }
       }
@@ -190,7 +190,7 @@ export default {
       id: '2',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/2'
+        self: 'https://kitsu.app/api/edge/anime/2'
       },
       createdAt: '2013-02-20T16:00:16.085Z',
       updatedAt: '2017-12-30T00:00:21.154Z',
@@ -239,11 +239,11 @@ export default {
       status: 'finished',
       tba: '',
       posterImage: {
-        tiny: 'https://media.kitsu.io/anime/poster_images/2/tiny.jpg?1435249715',
-        small: 'https://media.kitsu.io/anime/poster_images/2/small.jpg?1435249715',
-        medium: 'https://media.kitsu.io/anime/poster_images/2/medium.jpg?1435249715',
-        large: 'https://media.kitsu.io/anime/poster_images/2/large.jpg?1435249715',
-        original: 'https://media.kitsu.io/anime/poster_images/2/original.jpg?1435249715',
+        tiny: 'https://media.kitsu.app/anime/poster_images/2/tiny.jpg?1435249715',
+        small: 'https://media.kitsu.app/anime/poster_images/2/small.jpg?1435249715',
+        medium: 'https://media.kitsu.app/anime/poster_images/2/medium.jpg?1435249715',
+        large: 'https://media.kitsu.app/anime/poster_images/2/large.jpg?1435249715',
+        original: 'https://media.kitsu.app/anime/poster_images/2/original.jpg?1435249715',
         meta: {
           dimensions: {
             tiny: {
@@ -266,10 +266,10 @@ export default {
         }
       },
       coverImage: {
-        tiny: 'https://media.kitsu.io/anime/cover_images/2/tiny.jpg?1469656732',
-        small: 'https://media.kitsu.io/anime/cover_images/2/small.jpg?1469656732',
-        large: 'https://media.kitsu.io/anime/cover_images/2/large.jpg?1469656732',
-        original: 'https://media.kitsu.io/anime/cover_images/2/original.png?1469656732',
+        tiny: 'https://media.kitsu.app/anime/cover_images/2/tiny.jpg?1469656732',
+        small: 'https://media.kitsu.app/anime/cover_images/2/small.jpg?1469656732',
+        large: 'https://media.kitsu.app/anime/cover_images/2/large.jpg?1469656732',
+        original: 'https://media.kitsu.app/anime/cover_images/2/original.png?1469656732',
         meta: {
           dimensions: {
             tiny: {
@@ -295,74 +295,74 @@ export default {
       relationships: {
         genres: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/genres',
-            related: 'https://kitsu.io/api/edge/anime/2/genres'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/genres',
+            related: 'https://kitsu.app/api/edge/anime/2/genres'
           }
         },
         categories: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/categories',
-            related: 'https://kitsu.io/api/edge/anime/2/categories'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/categories',
+            related: 'https://kitsu.app/api/edge/anime/2/categories'
           }
         },
         castings: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/castings',
-            related: 'https://kitsu.io/api/edge/anime/2/castings'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/castings',
+            related: 'https://kitsu.app/api/edge/anime/2/castings'
           }
         },
         installments: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/installments',
-            related: 'https://kitsu.io/api/edge/anime/2/installments'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/installments',
+            related: 'https://kitsu.app/api/edge/anime/2/installments'
           }
         },
         mappings: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/mappings',
-            related: 'https://kitsu.io/api/edge/anime/2/mappings'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/mappings',
+            related: 'https://kitsu.app/api/edge/anime/2/mappings'
           }
         },
         reviews: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/reviews',
-            related: 'https://kitsu.io/api/edge/anime/2/reviews'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/reviews',
+            related: 'https://kitsu.app/api/edge/anime/2/reviews'
           }
         },
         mediaRelationships: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/media-relationships',
-            related: 'https://kitsu.io/api/edge/anime/2/media-relationships'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/media-relationships',
+            related: 'https://kitsu.app/api/edge/anime/2/media-relationships'
           }
         },
         episodes: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/episodes',
-            related: 'https://kitsu.io/api/edge/anime/2/episodes'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/episodes',
+            related: 'https://kitsu.app/api/edge/anime/2/episodes'
           }
         },
         streamingLinks: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/streaming-links',
-            related: 'https://kitsu.io/api/edge/anime/2/streaming-links'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/streaming-links',
+            related: 'https://kitsu.app/api/edge/anime/2/streaming-links'
           }
         },
         animeProductions: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-productions',
-            related: 'https://kitsu.io/api/edge/anime/2/anime-productions'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-productions',
+            related: 'https://kitsu.app/api/edge/anime/2/anime-productions'
           }
         },
         animeCharacters: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-characters',
-            related: 'https://kitsu.io/api/edge/anime/2/anime-characters'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-characters',
+            related: 'https://kitsu.app/api/edge/anime/2/anime-characters'
           }
         },
         animeStaff: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-staff',
-            related: 'https://kitsu.io/api/edge/anime/2/anime-staff'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-staff',
+            related: 'https://kitsu.app/api/edge/anime/2/anime-staff'
           }
         }
       }
@@ -372,8 +372,8 @@ export default {
     count: 12654
   },
   links: {
-    first: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=0',
-    next: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=2',
-    last: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=12652'
+    first: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=0',
+    next: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=2',
+    last: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=12652'
   }
 }

--- a/specification/getCollection/kitsu.js
+++ b/specification/getCollection/kitsu.js
@@ -5,77 +5,77 @@ export default {
     {
       id: '1',
       type: 'anime',
-      links: { self: 'https://kitsu.io/api/edge/anime/1' },
+      links: { self: 'https://kitsu.app/api/edge/anime/1' },
       genres: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/genres',
-          related: 'https://kitsu.io/api/edge/anime/1/genres'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/genres',
+          related: 'https://kitsu.app/api/edge/anime/1/genres'
         }
       },
       categories: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/categories',
-          related: 'https://kitsu.io/api/edge/anime/1/categories'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/categories',
+          related: 'https://kitsu.app/api/edge/anime/1/categories'
         }
       },
       castings: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/castings',
-          related: 'https://kitsu.io/api/edge/anime/1/castings'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/castings',
+          related: 'https://kitsu.app/api/edge/anime/1/castings'
         }
       },
       installments: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/installments',
-          related: 'https://kitsu.io/api/edge/anime/1/installments'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/installments',
+          related: 'https://kitsu.app/api/edge/anime/1/installments'
         }
       },
       mappings: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/mappings',
-          related: 'https://kitsu.io/api/edge/anime/1/mappings'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/mappings',
+          related: 'https://kitsu.app/api/edge/anime/1/mappings'
         }
       },
       reviews: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/reviews',
-          related: 'https://kitsu.io/api/edge/anime/1/reviews'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/reviews',
+          related: 'https://kitsu.app/api/edge/anime/1/reviews'
         }
       },
       mediaRelationships: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/media-relationships',
-          related: 'https://kitsu.io/api/edge/anime/1/media-relationships'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/media-relationships',
+          related: 'https://kitsu.app/api/edge/anime/1/media-relationships'
         }
       },
       episodes: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/episodes',
-          related: 'https://kitsu.io/api/edge/anime/1/episodes'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/episodes',
+          related: 'https://kitsu.app/api/edge/anime/1/episodes'
         }
       },
       streamingLinks: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/streaming-links',
-          related: 'https://kitsu.io/api/edge/anime/1/streaming-links'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/streaming-links',
+          related: 'https://kitsu.app/api/edge/anime/1/streaming-links'
         }
       },
       animeProductions: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-productions',
-          related: 'https://kitsu.io/api/edge/anime/1/anime-productions'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-productions',
+          related: 'https://kitsu.app/api/edge/anime/1/anime-productions'
         }
       },
       animeCharacters: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-characters',
-          related: 'https://kitsu.io/api/edge/anime/1/anime-characters'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-characters',
+          related: 'https://kitsu.app/api/edge/anime/1/anime-characters'
         }
       },
       animeStaff: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/anime-staff',
-          related: 'https://kitsu.io/api/edge/anime/1/anime-staff'
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/anime-staff',
+          related: 'https://kitsu.app/api/edge/anime/1/anime-staff'
         }
       },
       createdAt: '2013-02-20T16:00:13.609Z',
@@ -120,11 +120,11 @@ export default {
       status: 'finished',
       tba: '',
       posterImage: {
-        tiny: 'https://media.kitsu.io/anime/poster_images/1/tiny.jpg?1431697256',
-        small: 'https://media.kitsu.io/anime/poster_images/1/small.jpg?1431697256',
-        medium: 'https://media.kitsu.io/anime/poster_images/1/medium.jpg?1431697256',
-        large: 'https://media.kitsu.io/anime/poster_images/1/large.jpg?1431697256',
-        original: 'https://media.kitsu.io/anime/poster_images/1/original.jpg?1431697256',
+        tiny: 'https://media.kitsu.app/anime/poster_images/1/tiny.jpg?1431697256',
+        small: 'https://media.kitsu.app/anime/poster_images/1/small.jpg?1431697256',
+        medium: 'https://media.kitsu.app/anime/poster_images/1/medium.jpg?1431697256',
+        large: 'https://media.kitsu.app/anime/poster_images/1/large.jpg?1431697256',
+        original: 'https://media.kitsu.app/anime/poster_images/1/original.jpg?1431697256',
         meta: {
           dimensions: {
             tiny: { width: null, height: null },
@@ -135,10 +135,10 @@ export default {
         }
       },
       coverImage: {
-        tiny: 'https://media.kitsu.io/anime/cover_images/1/tiny.jpg?1416336000',
-        small: 'https://media.kitsu.io/anime/cover_images/1/small.jpg?1416336000',
-        large: 'https://media.kitsu.io/anime/cover_images/1/large.jpg?1416336000',
-        original: 'https://media.kitsu.io/anime/cover_images/1/original.jpg?1416336000',
+        tiny: 'https://media.kitsu.app/anime/cover_images/1/tiny.jpg?1416336000',
+        small: 'https://media.kitsu.app/anime/cover_images/1/small.jpg?1416336000',
+        large: 'https://media.kitsu.app/anime/cover_images/1/large.jpg?1416336000',
+        original: 'https://media.kitsu.app/anime/cover_images/1/original.jpg?1416336000',
         meta: {
           dimensions: {
             tiny: { width: null, height: null },
@@ -156,7 +156,7 @@ export default {
     {
       id: '2',
       type: 'anime',
-      links: { self: 'https://kitsu.io/api/edge/anime/2' },
+      links: { self: 'https://kitsu.app/api/edge/anime/2' },
       createdAt: '2013-02-20T16:00:16.085Z',
       updatedAt: '2017-12-30T00:00:21.154Z',
       slug: 'cowboy-bebop-tengoku-no-tobira',
@@ -206,11 +206,11 @@ export default {
       status: 'finished',
       tba: '',
       posterImage: {
-        tiny: 'https://media.kitsu.io/anime/poster_images/2/tiny.jpg?1435249715',
-        small: 'https://media.kitsu.io/anime/poster_images/2/small.jpg?1435249715',
-        medium: 'https://media.kitsu.io/anime/poster_images/2/medium.jpg?1435249715',
-        large: 'https://media.kitsu.io/anime/poster_images/2/large.jpg?1435249715',
-        original: 'https://media.kitsu.io/anime/poster_images/2/original.jpg?1435249715',
+        tiny: 'https://media.kitsu.app/anime/poster_images/2/tiny.jpg?1435249715',
+        small: 'https://media.kitsu.app/anime/poster_images/2/small.jpg?1435249715',
+        medium: 'https://media.kitsu.app/anime/poster_images/2/medium.jpg?1435249715',
+        large: 'https://media.kitsu.app/anime/poster_images/2/large.jpg?1435249715',
+        original: 'https://media.kitsu.app/anime/poster_images/2/original.jpg?1435249715',
         meta: {
           dimensions: {
             tiny: { width: null, height: null },
@@ -221,10 +221,10 @@ export default {
         }
       },
       coverImage: {
-        tiny: 'https://media.kitsu.io/anime/cover_images/2/tiny.jpg?1469656732',
-        small: 'https://media.kitsu.io/anime/cover_images/2/small.jpg?1469656732',
-        large: 'https://media.kitsu.io/anime/cover_images/2/large.jpg?1469656732',
-        original: 'https://media.kitsu.io/anime/cover_images/2/original.png?1469656732',
+        tiny: 'https://media.kitsu.app/anime/cover_images/2/tiny.jpg?1469656732',
+        small: 'https://media.kitsu.app/anime/cover_images/2/small.jpg?1469656732',
+        large: 'https://media.kitsu.app/anime/cover_images/2/large.jpg?1469656732',
+        original: 'https://media.kitsu.app/anime/cover_images/2/original.png?1469656732',
         meta: {
           dimensions: {
             tiny: { width: null, height: null },
@@ -240,82 +240,82 @@ export default {
       nsfw: false,
       genres: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/genres',
-          related: 'https://kitsu.io/api/edge/anime/2/genres'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/genres',
+          related: 'https://kitsu.app/api/edge/anime/2/genres'
         }
       },
       categories: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/categories',
-          related: 'https://kitsu.io/api/edge/anime/2/categories'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/categories',
+          related: 'https://kitsu.app/api/edge/anime/2/categories'
         }
       },
       castings: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/castings',
-          related: 'https://kitsu.io/api/edge/anime/2/castings'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/castings',
+          related: 'https://kitsu.app/api/edge/anime/2/castings'
         }
       },
       installments: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/installments',
-          related: 'https://kitsu.io/api/edge/anime/2/installments'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/installments',
+          related: 'https://kitsu.app/api/edge/anime/2/installments'
         }
       },
       mappings: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/mappings',
-          related: 'https://kitsu.io/api/edge/anime/2/mappings'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/mappings',
+          related: 'https://kitsu.app/api/edge/anime/2/mappings'
         }
       },
       reviews: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/reviews',
-          related: 'https://kitsu.io/api/edge/anime/2/reviews'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/reviews',
+          related: 'https://kitsu.app/api/edge/anime/2/reviews'
         }
       },
       mediaRelationships: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/media-relationships',
-          related: 'https://kitsu.io/api/edge/anime/2/media-relationships'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/media-relationships',
+          related: 'https://kitsu.app/api/edge/anime/2/media-relationships'
         }
       },
       episodes: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/episodes',
-          related: 'https://kitsu.io/api/edge/anime/2/episodes'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/episodes',
+          related: 'https://kitsu.app/api/edge/anime/2/episodes'
         }
       },
       streamingLinks: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/streaming-links',
-          related: 'https://kitsu.io/api/edge/anime/2/streaming-links'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/streaming-links',
+          related: 'https://kitsu.app/api/edge/anime/2/streaming-links'
         }
       },
       animeProductions: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-productions',
-          related: 'https://kitsu.io/api/edge/anime/2/anime-productions'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-productions',
+          related: 'https://kitsu.app/api/edge/anime/2/anime-productions'
         }
       },
       animeCharacters: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-characters',
-          related: 'https://kitsu.io/api/edge/anime/2/anime-characters'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-characters',
+          related: 'https://kitsu.app/api/edge/anime/2/anime-characters'
         }
       },
       animeStaff: {
         links: {
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/anime-staff',
-          related: 'https://kitsu.io/api/edge/anime/2/anime-staff'
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/anime-staff',
+          related: 'https://kitsu.app/api/edge/anime/2/anime-staff'
         }
       }
     }
   ],
   meta: { count: 12654 },
   links: {
-    first: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=0',
-    next: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=2',
-    last: 'https://kitsu.io/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=12652'
+    first: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=0',
+    next: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=2',
+    last: 'https://kitsu.app/api/edge/anime?page%5Blimit%5D=2&page%5Boffset%5D=12652'
   }
 }

--- a/specification/getCollectionWithIncludes/jsonapi.js
+++ b/specification/getCollectionWithIncludes/jsonapi.js
@@ -6,7 +6,7 @@ export default {
       id: '1',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/1'
+        self: 'https://kitsu.app/api/edge/anime/1'
       },
       attributes: {
         createdAt: '2013-02-20T16:00:13.609Z',
@@ -57,11 +57,11 @@ export default {
         status: 'finished',
         tba: '',
         posterImage: {
-          tiny: 'https://media.kitsu.io/anime/poster_images/1/tiny.jpg?1431697256',
-          small: 'https://media.kitsu.io/anime/poster_images/1/small.jpg?1431697256',
-          medium: 'https://media.kitsu.io/anime/poster_images/1/medium.jpg?1431697256',
-          large: 'https://media.kitsu.io/anime/poster_images/1/large.jpg?1431697256',
-          original: 'https://media.kitsu.io/anime/poster_images/1/original.jpg?1431697256',
+          tiny: 'https://media.kitsu.app/anime/poster_images/1/tiny.jpg?1431697256',
+          small: 'https://media.kitsu.app/anime/poster_images/1/small.jpg?1431697256',
+          medium: 'https://media.kitsu.app/anime/poster_images/1/medium.jpg?1431697256',
+          large: 'https://media.kitsu.app/anime/poster_images/1/large.jpg?1431697256',
+          original: 'https://media.kitsu.app/anime/poster_images/1/original.jpg?1431697256',
           meta: {
             dimensions: {
               tiny: {
@@ -84,10 +84,10 @@ export default {
           }
         },
         coverImage: {
-          tiny: 'https://media.kitsu.io/anime/cover_images/1/tiny.jpg?1416336000',
-          small: 'https://media.kitsu.io/anime/cover_images/1/small.jpg?1416336000',
-          large: 'https://media.kitsu.io/anime/cover_images/1/large.jpg?1416336000',
-          original: 'https://media.kitsu.io/anime/cover_images/1/original.jpg?1416336000',
+          tiny: 'https://media.kitsu.app/anime/cover_images/1/tiny.jpg?1416336000',
+          small: 'https://media.kitsu.app/anime/cover_images/1/small.jpg?1416336000',
+          large: 'https://media.kitsu.app/anime/cover_images/1/large.jpg?1416336000',
+          original: 'https://media.kitsu.app/anime/cover_images/1/original.jpg?1416336000',
           meta: {
             dimensions: {
               tiny: {
@@ -114,8 +114,8 @@ export default {
       relationships: {
         categories: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/1/relationships/categories',
-            related: 'https://kitsu.io/api/edge/anime/1/categories'
+            self: 'https://kitsu.app/api/edge/anime/1/relationships/categories',
+            related: 'https://kitsu.app/api/edge/anime/1/categories'
           },
           data: [
             {
@@ -137,7 +137,7 @@ export default {
       id: '2',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/2'
+        self: 'https://kitsu.app/api/edge/anime/2'
       },
       attributes: {
         createdAt: '2013-02-20T16:00:16.085Z',
@@ -187,11 +187,11 @@ export default {
         status: 'finished',
         tba: '',
         posterImage: {
-          tiny: 'https://media.kitsu.io/anime/poster_images/2/tiny.jpg?1435249715',
-          small: 'https://media.kitsu.io/anime/poster_images/2/small.jpg?1435249715',
-          medium: 'https://media.kitsu.io/anime/poster_images/2/medium.jpg?1435249715',
-          large: 'https://media.kitsu.io/anime/poster_images/2/large.jpg?1435249715',
-          original: 'https://media.kitsu.io/anime/poster_images/2/original.jpg?1435249715',
+          tiny: 'https://media.kitsu.app/anime/poster_images/2/tiny.jpg?1435249715',
+          small: 'https://media.kitsu.app/anime/poster_images/2/small.jpg?1435249715',
+          medium: 'https://media.kitsu.app/anime/poster_images/2/medium.jpg?1435249715',
+          large: 'https://media.kitsu.app/anime/poster_images/2/large.jpg?1435249715',
+          original: 'https://media.kitsu.app/anime/poster_images/2/original.jpg?1435249715',
           meta: {
             dimensions: {
               tiny: {
@@ -214,10 +214,10 @@ export default {
           }
         },
         coverImage: {
-          tiny: 'https://media.kitsu.io/anime/cover_images/2/tiny.jpg?1469656732',
-          small: 'https://media.kitsu.io/anime/cover_images/2/small.jpg?1469656732',
-          large: 'https://media.kitsu.io/anime/cover_images/2/large.jpg?1469656732',
-          original: 'https://media.kitsu.io/anime/cover_images/2/original.png?1469656732',
+          tiny: 'https://media.kitsu.app/anime/cover_images/2/tiny.jpg?1469656732',
+          small: 'https://media.kitsu.app/anime/cover_images/2/small.jpg?1469656732',
+          large: 'https://media.kitsu.app/anime/cover_images/2/large.jpg?1469656732',
+          original: 'https://media.kitsu.app/anime/cover_images/2/original.png?1469656732',
           meta: {
             dimensions: {
               tiny: {
@@ -244,8 +244,8 @@ export default {
       relationships: {
         categories: {
           links: {
-            self: 'https://kitsu.io/api/edge/anime/2/relationships/categories',
-            related: 'https://kitsu.io/api/edge/anime/2/categories'
+            self: 'https://kitsu.app/api/edge/anime/2/relationships/categories',
+            related: 'https://kitsu.app/api/edge/anime/2/categories'
           },
           data: [
             {
@@ -266,7 +266,7 @@ export default {
       id: '155',
       type: 'categories',
       links: {
-        self: 'https://kitsu.io/api/edge/categories/155'
+        self: 'https://kitsu.app/api/edge/categories/155'
       },
       attributes: {
         createdAt: '2017-05-31T06:39:22.090Z',
@@ -281,8 +281,8 @@ export default {
       relationships: {
         parent: {
           links: {
-            self: 'https://kitsu.io/api/edge/categories/155/relationships/parent',
-            related: 'https://kitsu.io/api/edge/categories/155/parent'
+            self: 'https://kitsu.app/api/edge/categories/155/relationships/parent',
+            related: 'https://kitsu.app/api/edge/categories/155/parent'
           }
         }
       }
@@ -291,7 +291,7 @@ export default {
       id: '51',
       type: 'categories',
       links: {
-        self: 'https://kitsu.io/api/edge/categories/51'
+        self: 'https://kitsu.app/api/edge/categories/51'
       },
       attributes: {
         createdAt: '2017-05-31T06:38:47.070Z',
@@ -306,8 +306,8 @@ export default {
       relationships: {
         parent: {
           links: {
-            self: 'https://kitsu.io/api/edge/categories/51/relationships/parent',
-            related: 'https://kitsu.io/api/edge/categories/51/parent'
+            self: 'https://kitsu.app/api/edge/categories/51/relationships/parent',
+            related: 'https://kitsu.app/api/edge/categories/51/parent'
           }
         }
       }
@@ -316,7 +316,7 @@ export default {
       id: '150',
       type: 'categories',
       links: {
-        self: 'https://kitsu.io/api/edge/categories/150'
+        self: 'https://kitsu.app/api/edge/categories/150'
       },
       attributes: {
         createdAt: '2017-05-31T06:39:20.357Z',
@@ -331,8 +331,8 @@ export default {
       relationships: {
         parent: {
           links: {
-            self: 'https://kitsu.io/api/edge/categories/150/relationships/parent',
-            related: 'https://kitsu.io/api/edge/categories/150/parent'
+            self: 'https://kitsu.app/api/edge/categories/150/relationships/parent',
+            related: 'https://kitsu.app/api/edge/categories/150/parent'
           }
         }
       }
@@ -342,8 +342,8 @@ export default {
     count: 12654
   },
   links: {
-    first: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=0',
-    next: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=2',
-    last: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=12652'
+    first: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=0',
+    next: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=2',
+    last: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=12652'
   }
 }

--- a/specification/getCollectionWithIncludes/kitsu.js
+++ b/specification/getCollectionWithIncludes/kitsu.js
@@ -6,7 +6,7 @@ export default {
       id: '1',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/1'
+        self: 'https://kitsu.app/api/edge/anime/1'
       },
       createdAt: '2013-02-20T16:00:13.609Z',
       updatedAt: '2017-12-30T00:49:40.721Z',
@@ -56,11 +56,11 @@ export default {
       status: 'finished',
       tba: '',
       posterImage: {
-        tiny: 'https://media.kitsu.io/anime/poster_images/1/tiny.jpg?1431697256',
-        small: 'https://media.kitsu.io/anime/poster_images/1/small.jpg?1431697256',
-        medium: 'https://media.kitsu.io/anime/poster_images/1/medium.jpg?1431697256',
-        large: 'https://media.kitsu.io/anime/poster_images/1/large.jpg?1431697256',
-        original: 'https://media.kitsu.io/anime/poster_images/1/original.jpg?1431697256',
+        tiny: 'https://media.kitsu.app/anime/poster_images/1/tiny.jpg?1431697256',
+        small: 'https://media.kitsu.app/anime/poster_images/1/small.jpg?1431697256',
+        medium: 'https://media.kitsu.app/anime/poster_images/1/medium.jpg?1431697256',
+        large: 'https://media.kitsu.app/anime/poster_images/1/large.jpg?1431697256',
+        original: 'https://media.kitsu.app/anime/poster_images/1/original.jpg?1431697256',
         meta: {
           dimensions: {
             tiny: {
@@ -83,10 +83,10 @@ export default {
         }
       },
       coverImage: {
-        tiny: 'https://media.kitsu.io/anime/cover_images/1/tiny.jpg?1416336000',
-        small: 'https://media.kitsu.io/anime/cover_images/1/small.jpg?1416336000',
-        large: 'https://media.kitsu.io/anime/cover_images/1/large.jpg?1416336000',
-        original: 'https://media.kitsu.io/anime/cover_images/1/original.jpg?1416336000',
+        tiny: 'https://media.kitsu.app/anime/cover_images/1/tiny.jpg?1416336000',
+        small: 'https://media.kitsu.app/anime/cover_images/1/small.jpg?1416336000',
+        large: 'https://media.kitsu.app/anime/cover_images/1/large.jpg?1416336000',
+        original: 'https://media.kitsu.app/anime/cover_images/1/original.jpg?1416336000',
         meta: {
           dimensions: {
             tiny: {
@@ -111,8 +111,8 @@ export default {
       nsfw: false,
       categories: {
         links: {
-          related: 'https://kitsu.io/api/edge/anime/1/categories',
-          self: 'https://kitsu.io/api/edge/anime/1/relationships/categories'
+          related: 'https://kitsu.app/api/edge/anime/1/categories',
+          self: 'https://kitsu.app/api/edge/anime/1/relationships/categories'
         },
         data: [
           {
@@ -121,7 +121,7 @@ export default {
             id: '155',
             image: null,
             links: {
-              self: 'https://kitsu.io/api/edge/categories/155'
+              self: 'https://kitsu.app/api/edge/categories/155'
             },
             meta: {
               dic1: 'def1'
@@ -129,8 +129,8 @@ export default {
             nsfw: false,
             parent: {
               links: {
-                related: 'https://kitsu.io/api/edge/categories/155/parent',
-                self: 'https://kitsu.io/api/edge/categories/155/relationships/parent'
+                related: 'https://kitsu.app/api/edge/categories/155/parent',
+                self: 'https://kitsu.app/api/edge/categories/155/relationships/parent'
               }
             },
             slug: 'science-fiction',
@@ -145,13 +145,13 @@ export default {
             id: '51',
             image: null,
             links: {
-              self: 'https://kitsu.io/api/edge/categories/51'
+              self: 'https://kitsu.app/api/edge/categories/51'
             },
             nsfw: false,
             parent: {
               links: {
-                related: 'https://kitsu.io/api/edge/categories/51/parent',
-                self: 'https://kitsu.io/api/edge/categories/51/relationships/parent'
+                related: 'https://kitsu.app/api/edge/categories/51/parent',
+                self: 'https://kitsu.app/api/edge/categories/51/relationships/parent'
               }
             },
             slug: 'space',
@@ -167,7 +167,7 @@ export default {
       id: '2',
       type: 'anime',
       links: {
-        self: 'https://kitsu.io/api/edge/anime/2'
+        self: 'https://kitsu.app/api/edge/anime/2'
       },
       createdAt: '2013-02-20T16:00:16.085Z',
       updatedAt: '2017-12-30T00:00:21.154Z',
@@ -216,11 +216,11 @@ export default {
       status: 'finished',
       tba: '',
       posterImage: {
-        tiny: 'https://media.kitsu.io/anime/poster_images/2/tiny.jpg?1435249715',
-        small: 'https://media.kitsu.io/anime/poster_images/2/small.jpg?1435249715',
-        medium: 'https://media.kitsu.io/anime/poster_images/2/medium.jpg?1435249715',
-        large: 'https://media.kitsu.io/anime/poster_images/2/large.jpg?1435249715',
-        original: 'https://media.kitsu.io/anime/poster_images/2/original.jpg?1435249715',
+        tiny: 'https://media.kitsu.app/anime/poster_images/2/tiny.jpg?1435249715',
+        small: 'https://media.kitsu.app/anime/poster_images/2/small.jpg?1435249715',
+        medium: 'https://media.kitsu.app/anime/poster_images/2/medium.jpg?1435249715',
+        large: 'https://media.kitsu.app/anime/poster_images/2/large.jpg?1435249715',
+        original: 'https://media.kitsu.app/anime/poster_images/2/original.jpg?1435249715',
         meta: {
           dimensions: {
             tiny: {
@@ -243,10 +243,10 @@ export default {
         }
       },
       coverImage: {
-        tiny: 'https://media.kitsu.io/anime/cover_images/2/tiny.jpg?1469656732',
-        small: 'https://media.kitsu.io/anime/cover_images/2/small.jpg?1469656732',
-        large: 'https://media.kitsu.io/anime/cover_images/2/large.jpg?1469656732',
-        original: 'https://media.kitsu.io/anime/cover_images/2/original.png?1469656732',
+        tiny: 'https://media.kitsu.app/anime/cover_images/2/tiny.jpg?1469656732',
+        small: 'https://media.kitsu.app/anime/cover_images/2/small.jpg?1469656732',
+        large: 'https://media.kitsu.app/anime/cover_images/2/large.jpg?1469656732',
+        original: 'https://media.kitsu.app/anime/cover_images/2/original.png?1469656732',
         meta: {
           dimensions: {
             tiny: {
@@ -271,8 +271,8 @@ export default {
       nsfw: false,
       categories: {
         links: {
-          related: 'https://kitsu.io/api/edge/anime/2/categories',
-          self: 'https://kitsu.io/api/edge/anime/2/relationships/categories'
+          related: 'https://kitsu.app/api/edge/anime/2/categories',
+          self: 'https://kitsu.app/api/edge/anime/2/relationships/categories'
         },
         data: [
           {
@@ -281,13 +281,13 @@ export default {
             id: '155',
             image: null,
             links: {
-              self: 'https://kitsu.io/api/edge/categories/155'
+              self: 'https://kitsu.app/api/edge/categories/155'
             },
             nsfw: false,
             parent: {
               links: {
-                related: 'https://kitsu.io/api/edge/categories/155/parent',
-                self: 'https://kitsu.io/api/edge/categories/155/relationships/parent'
+                related: 'https://kitsu.app/api/edge/categories/155/parent',
+                self: 'https://kitsu.app/api/edge/categories/155/relationships/parent'
               }
             },
             slug: 'science-fiction',
@@ -302,13 +302,13 @@ export default {
             id: '150',
             image: null,
             links: {
-              self: 'https://kitsu.io/api/edge/categories/150'
+              self: 'https://kitsu.app/api/edge/categories/150'
             },
             nsfw: false,
             parent: {
               links: {
-                related: 'https://kitsu.io/api/edge/categories/150/parent',
-                self: 'https://kitsu.io/api/edge/categories/150/relationships/parent'
+                related: 'https://kitsu.app/api/edge/categories/150/parent',
+                self: 'https://kitsu.app/api/edge/categories/150/relationships/parent'
               }
             },
             slug: 'action',
@@ -325,8 +325,8 @@ export default {
     count: 12654
   },
   links: {
-    first: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=0',
-    next: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=2',
-    last: 'https://kitsu.io/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=12652'
+    first: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=0',
+    next: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=2',
+    last: 'https://kitsu.app/api/edge/anime?include=categories&page%5Blimit%5D=2&page%5Boffset%5D=12652'
   }
 }


### PR DESCRIPTION
Kitsu switched domains in 2024. The API endpoint redirects to kitsu.app, but we should transition to it by default.